### PR TITLE
Change order of device_type/id in Context

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -42,10 +42,10 @@ typedef enum {
  * \brief A Device context for Tensor and operator.
  */
 typedef struct {
-  /*! \brief The device index */
-  int device_id;
   /*! \brief The device type used in the device. */
   DLDeviceType device_type;
+  /*! \brief The device index */
+  int device_id;
 } DLContext;
 
 /*!


### PR DESCRIPTION
This won;t change code that depend on the data structure.

 During my recent experience with dlpack, i found it is quite often to do cpu(0), gpu(1), and device_type always comes before device_id.  So I proposed this PR
