### PR TITLE
New Struct for managing memory of DLTensor

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -114,6 +114,27 @@ typedef struct {
   /*! \brief The offset in bytes to the beginning pointer to data */
   uint64_t byte_offset;
 } DLTensor;
+
+/*!
+ * \brief C Tensor object, manage memory of DLTensor. This data structure is
+ *  intended to faciliate the borrowing of DLTensor by another framework. It is
+ *  not meant to transfer the tensor. When the borrowing framework doesn't need
+ *  the tensor, it should call the deleter to notify the host that the resource
+ *  is no longer needed.
+ */
+typedef struct DLManagedTensor {
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+  /*! \brief the context of the original host framework of DLManagedTensor in
+   *   which DLManagedTensor is used in the framework. It can also be NULL.
+   */
+  void * manager_ctx;
+  /*! \brief Destructor signature void (*)(void*) - this should be called
+   *   to destruct manager_ctx which holds the DLManagedTensor. It can be NULL
+   *   if there is no way for the caller to provide a reasonable destructor.
+   */
+  void (*deleter)(struct DLManagedTensor * self);
+} DLManagedTensor;
 #ifdef __cplusplus
 }  // DLPACK_EXTERN_C
 #endif


### PR DESCRIPTION
We recently incorporated using dlpack tensor conversions in PyTorch and also needed to do memory management. In order to do that, we introduce a new struct called `DLManagedTensor` which can hold a nullable pointer to the destructor function that users can define as they wish. More fields of the struct have been explained in the PR and the example usage of this struct can be found here:

https://github.com/zdevito/ATen/blob/master/src/ATen/DLConvertor.cpp

and PyTorch tests for dlpack conversions https://github.com/pytorch/pytorch/blob/master/test/test_torch.py#L4250 