### PR TITLE
Clarification for #30, #35, #39

### DIFF
--- a/apps/from_numpy/numpy_dlpack.c
+++ b/apps/from_numpy/numpy_dlpack.c
@@ -1,7 +1,8 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <dlpack/dlpack.h>
 
-DLManagedTensor given;
+DLManagedTensor *given = NULL;
 
 void display(DLManagedTensor a) {
   puts("On C side:");
@@ -37,9 +38,15 @@ void display(DLManagedTensor a) {
 
 void Give(DLManagedTensor dl_managed_tensor) {
   display(dl_managed_tensor);
-  given = dl_managed_tensor;
+  given = (DLManagedTensor *) malloc(sizeof(DLManagedTensor));
+  *given = dl_managed_tensor;
 }
 
 void Finalize() {
-  given.deleter(&given);
+  given->deleter(given);
+}
+
+void FreeHandle() {
+  free(given);
+  given = NULL;
 }

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -138,8 +138,8 @@ typedef struct {
   /*! \brief The shape of the tensor */
   int64_t* shape;
   /*!
-   * \brief strides of the tensor,
-   *  can be NULL, indicating tensor is compact.
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
    */
   int64_t* strides;
   /*! \brief The offset in bytes to the beginning pointer to data */
@@ -163,6 +163,7 @@ typedef struct DLManagedTensor {
   /*! \brief Destructor signature void (*)(void*) - this should be called
    *   to destruct manager_ctx which holds the DLManagedTensor. It can be NULL
    *   if there is no way for the caller to provide a reasonable destructor.
+   *   The destructors deletes the argument self as well.
    */
   void (*deleter)(struct DLManagedTensor * self);
 } DLManagedTensor;


### PR DESCRIPTION
3 things to clarify

1. `DLTensor::strides` means number of elements, not number of bytes. #30 
2. When `DLTensor::strides` is NULL, it is row-majored. #35
3. `DLManagedTensor::deleter` deletes `manager_ctx` as well as its argument `self`. #39