### PR TITLE
adding layout field to store tensor layout (ie. NCHW)

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -137,6 +137,8 @@ typedef struct {
   DLDataType dtype;
   /*! \brief The shape of the tensor */
   int64_t* shape;
+  /*! \brief The layout of the tensor (ie. NCHW) */
+  char* layout;
   /*!
    * \brief strides of the tensor (in number of elements, not bytes)
    *  can be NULL, indicating tensor is compact and row-majored.


### PR DESCRIPTION
We need a way to communicate the layout of the tensor (ie. NCHW, NHWC, or NHWC16, etc). This PR includes a char* layout field in the DLTensor.