### PR TITLE
add bfloat16 data type support

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -80,6 +80,7 @@ typedef enum {
   kDLInt = 0U,
   kDLUInt = 1U,
   kDLFloat = 2U,
+  kDLBfloat = 4U,
 } DLDataTypeCode;
 
 /*!


### PR DESCRIPTION
As discussed in https://github.com/dmlc/dlpack/issues/45, adding bfloat16 data type support.

@tqchen @szha  @pengzhao-intel @ZhennanQin