### PR TITLE
Support complex numbers in DLPack

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -81,8 +81,7 @@ typedef enum {
   kDLUInt = 1U,
   kDLFloat = 2U,
   kDLBfloat = 4U,
-  kDLComplex = 5U,    // C/C++/Python layout (compact struct per complex number)
-  kDLComplexS = 6U,  // alternative layout (a struct with two pointers to real & imag arrays)
+  kDLComplex = 5U,  // C/C++/Python layout (compact struct per complex number)
 } DLDataTypeCode;
 
 /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -90,7 +90,11 @@ typedef enum {
   kDLOpaqueHandle = 3U,
   /*! \brief bfloat16 */
   kDLBfloat = 4U,
-  kDLComplex = 5U,  // C/C++/Python layout (compact struct per complex number)
+  /*!
+   * \brief complex number
+   * C/C++/Python layout: compact struct per complex number)
+   */
+  kDLComplex = 5U,
 } DLDataTypeCode;
 
 /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -81,6 +81,8 @@ typedef enum {
   kDLUInt = 1U,
   kDLFloat = 2U,
   kDLBfloat = 4U,
+  kDLComplex = 8U,    // C/C++/Python layout (compact struct per complex number)
+  kDLComplexS = 16U,  // alternative layout (a struct with two pointers to real & imag arrays)
 } DLDataTypeCode;
 
 /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -81,8 +81,8 @@ typedef enum {
   kDLUInt = 1U,
   kDLFloat = 2U,
   kDLBfloat = 4U,
-  kDLComplex = 8U,    // C/C++/Python layout (compact struct per complex number)
-  kDLComplexS = 16U,  // alternative layout (a struct with two pointers to real & imag arrays)
+  kDLComplex = 5U,    // C/C++/Python layout (compact struct per complex number)
+  kDLComplexS = 6U,  // alternative layout (a struct with two pointers to real & imag arrays)
 } DLDataTypeCode;
 
 /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -92,7 +92,7 @@ typedef enum {
   kDLBfloat = 4U,
   /*!
    * \brief complex number
-   * C/C++/Python layout: compact struct per complex number)
+   * (C/C++/Python layout: compact struct per complex number)
    */
   kDLComplex = 5U,
 } DLDataTypeCode;


### PR DESCRIPTION
Close #50. 

This PR adds the last missing piece IMHO to DLPack, namely to support complex numbers commonly used in scientific computing and also increasingly in certain machine learning tasks.

As discussed in #50, there seems to be a need to support two different kinds of formats, namely structs of arrays (SoA) and arrays of structs (AoS). The latter (AoS) is the standard choice in C/C++/CUDA/HIP/Python/Numpy/CuPy/etc, so I took the liberty of simply calling it `kDLComplex`. We haven't converged on naming in #50, though, and I'm open to suggestions 🙂

**QUESTION**: Should I bump the DLPack version in this PR, or we can wait until the actual release?

cc: @rgommers @tqchen @hawkinsp 