### PR TITLE
Add a comment for complex numbers

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -109,6 +109,7 @@ typedef enum {
  *   - float: type_code = 2, bits = 32, lanes=1
  *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes=4
  *   - int8: type_code = 0, bits = 8, lanes=1
+ *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
  */
 typedef struct {
   /*!


### PR DESCRIPTION
Based on the ongoing discussion in https://github.com/pytorch/pytorch/pull/55365, we think it's best to clarify the expectation for complex numbers. There could be two legit ways to construct them:
```
complex64 -> type_code = 5, bits=64, lanes=1
```
or
```
complex64 -> type_code = 5, bits=32, lanes=2
```
While the latter is natural if one considers complex64=float2 (a 2-vector of floats), the former is natural to stress we are dealing with single datatype, not a compound/vector one.

cc: @rgommers @emcastillo