### PR TITLE
Add a note on alignment requirement of data pointer

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -143,9 +143,16 @@ typedef struct {
  */
 typedef struct {
   /*!
-   * \brief The opaque data pointer points to the allocated data. This will be
-   * CUDA device pointer or cl_mem handle in OpenCL. This pointer is always
-   * aligned to 256 bytes as in CUDA.
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
    *
    * For given DLTensor, the size of memory required to store the contents of
    * data is calculated as follows:


### PR DESCRIPTION
xref discussion in https://github.com/data-apis/array-api/issues/293

Code examples for current handling of the `data` and `byte_offset`
fields:

https://github.com/apache/tvm/blob/43c2ea72bcd9968531441189e172372c1d8a64cb/src/contrib/tf_op/tvm_dso_op_kernels.cc#L170

https://github.com/tensorflow/tensorflow/blob/0b6b491d21d6a4eb5fbab1cca565bc1e94ca9543/tensorflow/compiler/xla/python/dlpack.cc#L308

https://github.com/cupy/cupy/blob/1a1ac3a30930562580c61fb5f9ec44314c6a593b/cupy/_core/dlpack.pyx#L111

https://github.com/pytorch/pytorch/blob/4b9464f4b99750c31583e5e384bec4de927f588e/aten/src/ATen/DLConvertor.cpp#L236

Cc @leofang, @kkraus14, @seberg, @tqchen 