### PR TITLE
Add kDLHexagon for Qualcomm Hexagon DSP

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -75,6 +75,8 @@ typedef enum {
    *
    */
   kDLOneAPI = 14,
+  /*! \brief Qualcomm Hexagon DSP */
+  kDLHexagon = 15,
 } DLDeviceType;
 
 /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -76,7 +76,7 @@ typedef enum {
    */
   kDLOneAPI = 14,
   /*! \brief Qualcomm Hexagon DSP */
-  kDLHexagon = 15,
+  kDLHexagon = 16,
 } DLDeviceType;
 
 /*!


### PR DESCRIPTION
Officially support the Qualcomm Hexagon DSP as a DLPack device type.