### PR TITLE
Add a script to deploy docs on `gh-pages` branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test_linux:
+    name: Deploy Docs
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Configuring Test Environment
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install build-essential doxygen ghp-import
+        python3 -m pip install -U pip wheel
+
+    - name: Installing dependencies
+      run: |
+        python3 -m pip install -r doc_requirements.txt
+
+    - name: Generating Docs
+      run: |
+        make doc
+
+    - name: Deploying on GitHub Pages
+      run: |
+        touch docs/build/html/.nojekyll
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        git config --global user.email "dlpack-gh-actions-bot@nomail"
+        git config --global user.name "dlpack-gh-actions-bot"
+        ghp-import -m "Generate DLPack website" -b gh-pages docs/build/html
+        git push origin gh-pages -f


### PR DESCRIPTION
Follow-up of #90

This PR adds a script to deploy docs on GitHub Pages via the `gh-pages` branch that triggers on push to the main branch. I tested it on [my fork][3] and it seems to work there ([CI Logs][1], [Deployment][2]). Since the website is small, I think it's OK to push to a branch under the main repo.

[1]: https://github.com/tirthasheshpatel/dlpack/runs/5040102324?check_suite_focus=true
[2]: https://github.com/tirthasheshpatel/dlpack/deployments
[3]: https://github.com/tirthasheshpatel/dlpack