### PR TITLE
Fix deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Deploying on GitHub Pages
       run: |
-        touch docs/build/html/.nojekyll
+        touch docs/build/.nojekyll
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
         git config --global user.email "dlpack-gh-actions-bot@nomail"
         git config --global user.name "dlpack-gh-actions-bot"


### PR DESCRIPTION
#93 changed the build destination from https://dmlc.github.com/dlpack to https://dmlc.github.com/dlpack/latest. I thought this change might help with versioning in the future. I forgot to update one line in the deploy job which is why it's failing on `main` right now. This PR should fix this. I tested it on my fork and it publishes to the [right destination](https://tirthasheshpatel.github.io/dlpack/latest/).

cc @tqchen 