### PR TITLE
Add a note about non-native endianness

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -126,7 +126,8 @@ typedef enum {
 } DLDataTypeCode;
 
 /*!
- * \brief The data type the tensor can hold.
+ * \brief The data type the tensor can hold. Currently, non-native endianness isn't
+ * supported. Attempt to export such array must raise an error.
  *
  *  Examples
  *   - float: type_code = 2, bits = 32, lanes=1

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -126,8 +126,9 @@ typedef enum {
 } DLDataTypeCode;
 
 /*!
- * \brief The data type the tensor can hold. Currently, non-native endianness isn't
- * supported. Attempt to export such array must raise an error.
+ * \brief The data type the tensor can hold. The data type is assumed to follow the
+ * native endian-ness. An explicit error message should be raised when attempting to
+ * export an array with non-native endianness
  *
  *  Examples
  *   - float: type_code = 2, bits = 32, lanes=1


### PR DESCRIPTION
Addresses #97 

Added a note saying non-native endianness isn't supported and that exporting such arrays must raise an error. @tqchen Do we want this on the roadmap or should we consider it out of scope?