### PR TITLE
Add an ABI version

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -15,7 +15,7 @@
 #define DLPACK_EXTERN_C
 #endif
 
-/*! \brief The current API version of dlpack */
+/*! \brief The current version of dlpack */
 #define DLPACK_VERSION 60
 
 /*! \brief The current ABI version of dlpack */

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -15,8 +15,11 @@
 #define DLPACK_EXTERN_C
 #endif
 
-/*! \brief The current version of dlpack */
+/*! \brief The current API version of dlpack */
 #define DLPACK_VERSION 60
+
+/*! \brief The current ABI version of dlpack */
+#define DLPACK_ABI_VERSION 1
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32


### PR DESCRIPTION
Addresses the first point of https://github.com/dmlc/dlpack/issues/34#issuecomment-1074985553
Superceeds #72 

DLPack didn't have an ABI version anywhere in the header file before. This adds an ABI version as a macro and sets it to `1` i.e. v1. We can also have the ABI version with semvar e.g. `10` i.e. v0.1.0. But since ABI breaks are rare, a simple major version could work.

Once this goes in, we can change the `DLTensor` to include the versions and increment the ABI version to indicate a break:

cc @tqchen @rgommers @seberg @leofang @mattip