### PR TITLE
[ABI break] Append new fields to DLManagedTensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 # Set variables:
 #   * PROJECT_NAME
 #   * PROJECT_VERSION
-project(dlpack VERSION 0.6 LANGUAGES C CXX)
+project(dlpack VERSION 0.7 LANGUAGES C CXX)
 
 #####
 # Change the default build type from Debug to Release, while still

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, DLPack contributors'
 author = 'DLPack contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.0'
+release = '0.7.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -16,10 +16,10 @@
 #endif
 
 /*! \brief The current version of dlpack */
-#define DLPACK_VERSION 60
+#define DLPACK_VERSION 70
 
 /*! \brief The current ABI version of dlpack */
-#define DLPACK_ABI_VERSION 1
+#define DLPACK_ABI_VERSION 2
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32
@@ -222,6 +222,12 @@ typedef struct DLManagedTensor {
    *   The destructors deletes the argument self as well.
    */
   void (*deleter)(struct DLManagedTensor * self);
+  /* The version of the DLManagedTensor */
+  int32_t version;
+  /*! \brief Mark the data readonly. */
+  uint8_t readonly;
+  /*! \brief 128-bytes of padding to preserve ABI compatibility in the future. */
+  uint8_t __padding[128];
 } DLManagedTensor;
 #ifdef __cplusplus
 }  // DLPACK_EXTERN_C


### PR DESCRIPTION
Alternative to #101
Addresses #34 and #104
Implements the A1 alternative in https://github.com/dmlc/dlpack/issues/104#issuecomment-1090423607

Instead of appending the new fields to the `DLTesor` which changes the layout of `DLManagedTensor` in a backward incompatible manner, we can add the fields at the end of `DLManagedTensor` itself. This way we won't require new structs to maintain backward compatibility.

On Python front: should we add the `__dlpack_info__` dunder and a version keyword as proposed in #101? I'd say yes because, without knowing the requested version, the producer (exporter) cannot tell if it can export a certain type of array e.g. NumPy throws an error if one tries to export a readonly array with the old ABI. On the consumer (importer) side, it can't tell which fields are safe to access without knowing what version is being imported.

cc @tqchen @mattip @seberg @rgommers @leofang