### PR TITLE
[ABI] ABI Update For adding Version to DLPack

### DIFF
--- a/contrib/mock_main.cc
+++ b/contrib/mock_main.cc
@@ -3,7 +3,7 @@
 #include <dlpack/dlpackcpp.h>
 
 int CheckFlags(DLManagedTensorVersioned *data) {
-  if (data->flags & kDLFlagBitMaskReadOnly) {
+  if (data->flags & DLPACK_FLAG_BITMASK_READ_ONLY) {
     return 0;
   } else {
     return 1;

--- a/contrib/mock_main.cc
+++ b/contrib/mock_main.cc
@@ -2,6 +2,14 @@
 #include <dlpack/dlpack.h>
 #include <dlpack/dlpackcpp.h>
 
+int CheckFlags(DLManagedTensorVersioned *data) {
+  if (data->flags & kDLFlagBitMaskReadOnly) {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+
 int main() {
   dlpack::DLTContainer c;
   return 0;

--- a/docs/source/c_api.rst
+++ b/docs/source/c_api.rst
@@ -8,7 +8,9 @@ Macros
 
 .. doxygendefine:: DLPACK_EXTERN_C
 
-.. doxygendefine:: DLPACK_VERSION
+.. doxygendefine:: DLPACK_MAJOR_VERSION
+
+.. doxygendefine:: DLPACK_MINOR_VERSION
 
 .. doxygendefine:: DLPACK_DLL
 
@@ -22,6 +24,9 @@ Enumerations
 Structs
 ~~~~~~~
 
+.. doxygenstruct:: DLPackVersion
+   :members:
+
 .. doxygenstruct:: DLDevice
    :members:
 
@@ -32,4 +37,7 @@ Structs
    :members:
 
 .. doxygenstruct:: DLManagedTensor
+   :members:
+
+.. doxygenstruct:: DLManagedTensorVersioned
    :members:

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -47,9 +47,19 @@ extern "C" {
  *
  * A change in minor version indicates that we have added new
  * code, such as a new device type, but the ABI is kept the same.
+ *
+ * If an obtained DLPack tensor has a major version that disagrees
+ * with the version number specified in this header file
+ * (i.e. major != DLPACK_MAJOR_VERSION), the consumer must call the deleter
+ * (and it is safe to do so). It is not safe to access any other fields
+ * as the memory layout will have changed.
+ *
+ * In the case of a minor version mismatch, the tensor can be safely used as
+ * long as the consumer knows how to interpret all fields. Minor version
+ * updates indicate the addition of enumeration values.
  */
 typedef struct {
-  /*! \brief DLPack major version version. */
+  /*! \brief DLPack major version. */
   uint32_t major;
   /*! \brief DLPack minor version. */
   uint32_t minor;

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -15,11 +15,11 @@
 #define DLPACK_EXTERN_C
 #endif
 
-/*! \brief The current version of dlpack */
-#define DLPACK_VERSION 80
+/*! \brief The current major version of dlpack */
+#define DLPACK_MAJOR_VERSION 1
 
-/*! \brief The current ABI version of dlpack */
-#define DLPACK_ABI_VERSION 2
+/*! \brief The current minor version of dlpack */
+#define DLPACK_MINOR_VERSION 0
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32
@@ -40,19 +40,19 @@ extern "C" {
 #endif
 
 /*!
- * \brief The DLPack and DLPack ABI versions of the tensor.
+ * \brief The DLPack version.
  *
- * The DLPack version changes when we introduce new device type,
- * data type that is compatible with existing ones.
+ * A change in major version indicates that we have changed the
+ * data layout of the ABI - DLManagedTensorVersioned.
  *
- * The DLPack ABI version changes when we change the data layout
- * of the DLManagedTensorVersioned.
+ * A change in minor version indicates that we have added new
+ * code, such as a new device type, but the ABI is kept the same.
  */
 typedef struct {
-  /*! \brief DLPack version. */
-  uint32_t dlpack;
-  /*! \brief DLPack ABI version. */
-  uint32_t abi;
+  /*! \brief DLPack major version version. */
+  uint32_t major;
+  /*! \brief DLPack minor version. */
+  uint32_t minor;
 } DLPackVersion;
 
 /*!


### PR DESCRIPTION
This PR adds DLPackManagedTensorVersioned to DLPack

- Add a new data structure DLManagedTensorVersioned, which contains a new version field.
- Add DLPackVersion struct to indicate both api and abi versions.
- Add flags field for boolean options, with support for read only bit mask.
- Add kDLDeviceTypeEnd to help dependent packages to check range of possible extension values.

The change is still ABI compatible, as the new data structure ABI comes with the DLManagedTensorVersioned. The data-api however would involve an ABI update and update of all DLPack importer/exporters to make use of DLManagedTensorVersioned.