### PR TITLE
[RFC] [DeviceType] Add support for MAIA

### DIFF
--- a/apps/numpy_dlpack/dlpack/dlpack.py
+++ b/apps/numpy_dlpack/dlpack/dlpack.py
@@ -18,6 +18,7 @@ class DLDeviceType(ctypes.c_int):
     kDLROCMHost = 11
     kDLCUDAManaged = 13
     kDLOneAPI = 14
+    kDLMsNpu = 17
 
     def __str__(self):
         return {
@@ -32,6 +33,7 @@ class DLDeviceType(ctypes.c_int):
             self.kDLROCMHost: "ROMCHost",
             self.kDLCUDAManaged: "CUDAManaged",
             self.kDLOneAPI: "oneAPI",
+            self.kDLMsNpu: "MsNpu",
             }[self.value]
 
 

--- a/apps/numpy_dlpack/dlpack/dlpack.py
+++ b/apps/numpy_dlpack/dlpack/dlpack.py
@@ -18,7 +18,7 @@ class DLDeviceType(ctypes.c_int):
     kDLROCMHost = 11
     kDLCUDAManaged = 13
     kDLOneAPI = 14
-    kDLMsNpu = 17
+    kDLMAIA = 17
 
     def __str__(self):
         return {
@@ -33,7 +33,7 @@ class DLDeviceType(ctypes.c_int):
             self.kDLROCMHost: "ROMCHost",
             self.kDLCUDAManaged: "CUDAManaged",
             self.kDLOneAPI: "oneAPI",
-            self.kDLMsNpu: "MsNpu",
+            self.kDLMAIA: "MAIA",
             }[self.value]
 
 

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -116,6 +116,8 @@ typedef enum {
   kDLWebGPU = 15,
   /*! \brief Qualcomm Hexagon DSP */
   kDLHexagon = 16,
+  /*! \brief Microsoft NPU */
+  kDLMsNpu = 17,
 } DLDeviceType;
 
 /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -116,8 +116,8 @@ typedef enum {
   kDLWebGPU = 15,
   /*! \brief Qualcomm Hexagon DSP */
   kDLHexagon = 16,
-  /*! \brief Microsoft NPU */
-  kDLMsNpu = 17,
+  /*! \brief Microsoft MAIA devices */
+  kDLMAIA = 17,
 } DLDeviceType;
 
 /*!


### PR DESCRIPTION
This PR extends `DLDeviceType` to support Microsoft [MAIA devices](https://news.microsoft.com/source/features/ai/in-house-chips-silicon-to-service-to-meet-ai-demand/).