### PR TITLE
Add support for ORT device

### DIFF
--- a/apps/numpy_dlpack/dlpack/dlpack.py
+++ b/apps/numpy_dlpack/dlpack/dlpack.py
@@ -18,6 +18,7 @@ class DLDeviceType(ctypes.c_int):
     kDLROCMHost = 11
     kDLCUDAManaged = 13
     kDLOneAPI = 14
+    kDLOrt = 17
 
     def __str__(self):
         return {
@@ -32,6 +33,7 @@ class DLDeviceType(ctypes.c_int):
             self.kDLROCMHost: "ROMCHost",
             self.kDLCUDAManaged: "CUDAManaged",
             self.kDLOneAPI: "oneAPI",
+            self.kDLOrt: "Ort",
             }[self.value]
 
 

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -116,6 +116,8 @@ typedef enum {
   kDLWebGPU = 15,
   /*! \brief Qualcomm Hexagon DSP */
   kDLHexagon = 16,
+  /*! \brief Device abstract for onnxruntime (ORT) */
+  kDLOrt = 17,
 } DLDeviceType;
 
 /*!


### PR DESCRIPTION
This PR extends DLDeviceType to support [onnxruntime](https://github.com/microsoft/onnxruntime) (ORT) device. The ORT device is an device abstract for the integration of ORT eager-mode execution into AI frameworks using dlpack (e.g. [torch_ort](https://github.com/pytorch/ort)).
