### PR TITLE
Add a new bit mask for copy + Update Python array API spec

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==4.4.0
+Sphinx==5.*
 pydata-sphinx-theme==0.7.1
-breathe==4.31.0
+breathe>=4.31.0

--- a/docs/source/c_api.rst
+++ b/docs/source/c_api.rst
@@ -14,6 +14,10 @@ Macros
 
 .. doxygendefine:: DLPACK_DLL
 
+.. doxygendefine:: DLPACK_FLAG_BITMASK_READ_ONLY
+
+.. doxygendefine:: DLPACK_FLAG_BITMASK_IS_COPIED
+
 Enumerations
 ~~~~~~~~~~~~
 

--- a/docs/source/python_spec.rst
+++ b/docs/source/python_spec.rst
@@ -30,7 +30,7 @@ When a user calls ``y = from_dlpack(x)``, the library implementing ``x`` (the
 "producer") will provide access to the data from ``x`` to the library
 containing ``from_dlpack`` (the "consumer"). If possible, this must be
 zero-copy (i.e. ``y`` will be a *view* on ``x``). If not possible, that library
-may make a copy of the data. In both cases:
+may flag this and make a copy of the data. In both cases:
 
 - The producer keeps owning the memory of ``x`` (and ``y`` if a copy is made)
 - ``y`` may or may not be a view, therefore the user must keep the recommendation to
@@ -51,7 +51,7 @@ unnecessary so asynchronous execution is enabled.
 
 Starting Python array API standard v2023, a copy can be explicitly requested (or
 disabled) through the new ``copy`` argument of ``from_dlpack()``. When a copy is
-made, the producer should set the ``DLPACK_FLAG_BITMASK_IS_COPIED`` bit flag.
+made, the producer must set the ``DLPACK_FLAG_BITMASK_IS_COPIED`` bit flag.
 It is also possible to request cross-device copies through the new ``device``
 argument, though the v2023 standard only mandates the support of ``kDLCPU``.
 

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -262,7 +262,7 @@ typedef struct DLManagedTensor {
    * \brief Destructor - this should be called
    * to destruct the manager_ctx  which backs the DLManagedTensor. It can be
    * NULL if there is no way for the caller to provide a reasonable destructor.
-   * The destructors deletes the argument self as well.
+   * The destructor deletes the argument self as well.
    */
   void (*deleter)(struct DLManagedTensor * self);
 } DLManagedTensor;
@@ -272,7 +272,12 @@ typedef struct DLManagedTensor {
 /*! \brief bit mask to indicate that the tensor is read only. */
 #define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
 
-/*! \brief bit mask to indicate that the tensor is a copy made by the producer. */
+/*!
+ * \brief bit mask to indicate that the tensor is a copy made by the producer.
+ *
+ * If set, the tensor is considered solely owned throughout its lifetime by the
+ * consumer, until the producer-provided deleter is invoked.
+ */
 #define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
 
 /*!
@@ -302,7 +307,7 @@ struct DLManagedTensorVersioned {
    *
    * This should be called to destruct manager_ctx which holds the DLManagedTensorVersioned.
    * It can be NULL if there is no way for the caller to provide a reasonable
-   * destructor. The destructors deletes the argument self as well.
+   * destructor. The destructor deletes the argument self as well.
    */
   void (*deleter)(struct DLManagedTensorVersioned *self);
   /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -272,6 +272,9 @@ typedef struct DLManagedTensor {
 /*! \brief bit mask to indicate that the tensor is read only. */
 #define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
 
+/*! \brief bit mask to indicate that the tensor is a copy made by the producer. */
+#define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
+
 /*!
  * \brief A versioned and managed C Tensor object, manage memory of DLTensor.
  *
@@ -311,6 +314,7 @@ struct DLManagedTensorVersioned {
    *       stable, to ensure that deleter can be correctly called.
    *
    * \sa DLPACK_FLAG_BITMASK_READ_ONLY
+   * \sa DLPACK_FLAG_BITMASK_IS_COPIED
    */
   uint64_t flags;
   /*! \brief DLTensor which is being memory managed */


### PR DESCRIPTION
Close #116. Close #134. Close #132.

This PR is an accompanying PR for https://github.com/data-apis/array-api/pull/602 and https://github.com/data-apis/array-api/pull/741. It does a few things to prepare for the release of Python array API standard v2023:
- Add a new `DLPACK_FLAG_BITMASK_IS_COPIED` bit mask to indicate if a copy has been made by the producer (#134)
- Add the missing bit mask docs to the C API reference 
- Update the Python API specs:
   - `max_version` is added to `__dlpack__` to support the transition from DLPack 0.x to 1.x (#116) 
   - `copy` is added to `from_dlpack` and `__dlpack__` to allow explicit copy requests (#134)
   - `device` (`dl_device`) is added to `from_dlpack` (`__dlpack__`) to allow cross-device copies (#132). However, currently we only mandate the support of device-to-host copies.
   - Mention that the new versioned tensor should be used and the proper treatment for DLPack 1.0+