### PR TITLE
DOC: Update link to mpi4py implementation

### DIFF
--- a/docs/source/python_spec.rst
+++ b/docs/source/python_spec.rst
@@ -195,4 +195,4 @@ ctypes, cffi, etc:
 * MXNet: `ctypes <https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/dlpack.py>`__
 * TVM: `ctypes <https://github.com/apache/tvm/blob/main/python/tvm/_ffi/_ctypes/ndarray.py>`__,
   `Cython <https://github.com/apache/tvm/blob/main/python/tvm/_ffi/_cython/ndarray.pxi>`__
-* mpi4py: `Cython <https://github.com/mpi4py/mpi4py/blob/master/src/mpi4py/MPI/asdlpack.pxi>`_
+* mpi4py: `Cython <https://github.com/mpi4py/mpi4py/blob/master/src/mpi4py/MPI.src/asdlpack.pxi>`_

--- a/docs/source/python_spec.rst
+++ b/docs/source/python_spec.rst
@@ -185,7 +185,7 @@ Reference Implementations
 Several Python libraries have adopted this standard using Python C API, C++, Cython,
 ctypes, cffi, etc:
 
-* NumPy: `Python C API <https://github.com/numpy/numpy/blob/main/numpy/core/src/multiarray/dlpack.c>`__
+* NumPy: `Python C API <https://github.com/numpy/numpy/blob/main/numpy/_core/src/multiarray/dlpack.c>`__
 * CuPy: `Cython <https://github.com/cupy/cupy/blob/master/cupy/_core/dlpack.pyx>`__
 * Tensorflow: `C++ <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/c/eager/dlpack.cc>`__,
   `Python wrapper using Python C API <https://github.com/tensorflow/tensorflow/blob/a97b01a4ff009ed84a571c138837130a311e74a7/tensorflow/python/tfe_wrapper.cc#L1562>`__,

--- a/docs/source/python_spec.rst
+++ b/docs/source/python_spec.rst
@@ -189,7 +189,7 @@ ctypes, cffi, etc:
 * CuPy: `Cython <https://github.com/cupy/cupy/blob/master/cupy/_core/dlpack.pyx>`__
 * Tensorflow: `C++ <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/c/eager/dlpack.cc>`__,
   `Python wrapper using Python C API <https://github.com/tensorflow/tensorflow/blob/a97b01a4ff009ed84a571c138837130a311e74a7/tensorflow/python/tfe_wrapper.cc#L1562>`__,
-  `XLA <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/python/dlpack.cc>`__
+  `XLA <https://github.com/tensorflow/tensorflow/blob/master/third_party/xla/xla/python/dlpack.cc>`__
 * PyTorch: `C++ <https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/DLConvertor.cpp>`__,
   `Python wrapper using Python C API <https://github.com/pytorch/pytorch/blob/c22b8a42e6038ed2f6a161114cf3d8faac3f6e9a/torch/csrc/Module.cpp#L355>`__
 * MXNet: `ctypes <https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/dlpack.py>`__


### PR DESCRIPTION
Update the link to the mpi4py implementation as it is currently pointing to 404 error page:

![404-error-page](https://github.com/dmlc/dlpack/assets/16418547/b09eba08-0a7c-4348-8693-19c0409364c5)
