### PR TITLE
Add fp8/fp6/fp4 types

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -157,6 +157,20 @@ typedef enum {
   kDLComplex = 5U,
   /*! \brief boolean */
   kDLBool = 6U,
+  /*! \brief FP8 data types. Must set DLDataType.bits=8. */
+  kDLFloat8_e3m4 = 7U,
+  kDLFloat8_e4m3 = 8U,
+  kDLFloat8_e4m3b11fnuz = 9U,
+  kDLFloat8_e4m3fn = 10U,
+  kDLFloat8_e4m3fnuz = 11U,
+  kDLFloat8_e5m2 = 12U,
+  kDLFloat8_e5m2fnuz = 13U,
+  kDLFloat8_e8m0fnu = 14U,
+  /*! \brief FP6 data types. Must set DLDataType.bits=6. */
+  kDLFloat6_e2m3fn = 15U,
+  kDLFloat6_e3m2fn = 16U,
+  /*! \brief FP4 data types. Must set DLDataType.bits=4. */
+  kDLFloat4_e2m1fn = 17U,
 } DLDataTypeCode;
 
 /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -193,6 +193,9 @@ typedef enum {
  *   - float8_e4m3: type_code = 8, bits = 8, lanes = 1 (packed in memory)
  *   - float6_e3m2fn: type_code = 16, bits = 6, lanes = 1 (packed in memory)
  *   - float4_e2m1fn: type_code = 17, bits = 4, lanes = 1 (packed in memory)
+ *
+ *  When a sub-byte type is packed, DLPack requires the data to be in little bit-endian, i.e.,
+ *  for a packed data set D ((D >> (i * bits)) && bit_mask) stores the i-th element.
  */
 typedef struct {
   /*!
@@ -302,6 +305,14 @@ typedef struct DLManagedTensor {
  * consumer, until the producer-provided deleter is invoked.
  */
 #define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
+
+/*
+ * \brief bit mask to indicate that whether a sub-byte type is packed or padded.
+ *
+ * The default for sub-byte types (ex: fp4/fp6) is assumed packed. This flag can
+ * be set by the producer to signal that a tensor of sub-byte type is padded.
+ */
+#define DLPACK_FLAG_BITMASK_IS_SUBBYTE_TYPE_PADDED (1UL << 2UL)
 
 /*!
  * \brief A versioned and managed C Tensor object, manage memory of DLTensor.

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -157,7 +157,7 @@ typedef enum {
   kDLComplex = 5U,
   /*! \brief boolean */
   kDLBool = 6U,
-  /*! \brief FP8 data types. Must set DLDataType.bits=8. */
+  /*! \brief FP8 data types */
   kDLFloat8_e3m4 = 7U,
   kDLFloat8_e4m3 = 8U,
   kDLFloat8_e4m3b11fnuz = 9U,
@@ -166,10 +166,16 @@ typedef enum {
   kDLFloat8_e5m2 = 12U,
   kDLFloat8_e5m2fnuz = 13U,
   kDLFloat8_e8m0fnu = 14U,
-  /*! \brief FP6 data types. Must set DLDataType.bits=6. */
+  /*! \brief FP6 data types
+   * Setting bits != 6 is currently unspecified, and the producer must ensure it is set
+   * while the consumer must stop importing if the value is unexpected.
+   */
   kDLFloat6_e2m3fn = 15U,
   kDLFloat6_e3m2fn = 16U,
-  /*! \brief FP4 data types. Must set DLDataType.bits=4. */
+  /*! \brief FP4 data types
+   * Setting bits != 4 is currently unspecified, and the producer must ensure it is set
+   * while the consumer must stop importing if the value is unexpected.
+   */
   kDLFloat4_e2m1fn = 17U,
 } DLDataTypeCode;
 
@@ -184,6 +190,9 @@ typedef enum {
  *   - int8: type_code = 0, bits = 8, lanes = 1
  *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
  *   - bool: type_code = 6, bits = 8, lanes = 1 (as per common array library convention, the underlying storage size of bool is 8 bits)
+ *   - float8_e4m3: type_code = 8, bits = 8, lanes = 1 (packed in memory)
+ *   - float6_e3m2fn: type_code = 16, bits = 6, lanes = 1 (packed in memory)
+ *   - float4_e2m1fn: type_code = 17, bits = 4, lanes = 1 (packed in memory)
  */
 typedef struct {
   /*!


### PR DESCRIPTION
Close #156. 

As discussed in the Python Array API meeting last week (Feb 6), I am adding additional data type enumerators based on user requests from, e.g., #156, https://github.com/pytorch/pytorch/issues/146414, and NVIDIA internal teams.

cc @tqchen @rgommers @seberg @oleksandr-pavlyk @hawkinsp @jakevdp @kmaehashi @kkraus14 @ptrblck @nouiz