### PR TITLE
Update minimum cmake required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 ###
-# Set minimum version of CMake. Since command 'project' use
-# VERSION sub-option we need at least 3.0.
-# Note: If you use 2.6 or 2.4, God kills a kitten. Seriously.
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+# Set minimum version of CMake. CMake 4.0 drops support for CMake<3.06 so that
+# is the absolute lowest that we could allow without blocking the usage of new
+# versions of CMake. Using 3.16 since it is the supported version on Ubuntu
+# 20.04 LTS (using that as a representative distro for our desired level of
+# backwards compatibility).
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 ####
 # Set variables:


### PR DESCRIPTION
This PR updates the minimum required version of CMake. This change is necessary because the CMake 4.0 release [removed policies that allowed supporting such old versions of CMake](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features), so having such a low required minimum version of CMake prohibits using the latest versions. CMake 3.16 is already quite old (the release was [back in 2019](https://www.kitware.com/cmake-3-16-0-available-for-download/)) and it is a reasonable choice based on Linux distro support (for example, [it is the supported version for Ubuntu's 20.04 LTS release](https://packages.ubuntu.com/search?suite=focal&searchon=names&keywords=cmake)).

Resolves #162 