### PR TITLE
Enhancement: Add clarification on use of dlpack for kDLOneAPI devices

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -110,7 +110,7 @@ typedef enum {
    * device. Either a call to oneAPI runtime is required to determine the
    * device type, the USM allocation type and the sycl context it is
    * bound to, or the requisite information should be available via the
-   * manager_ctx.
+   * `manager_ctx`.
    */
   kDLOneAPI = 14,
   /*! \brief GPU support for next generation WebGPU standard. */

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -106,10 +106,11 @@ typedef enum {
    */
   kDLCUDAManaged = 13,
   /*!
-   * \brief Unified shared memory allocated on a oneAPI non-partititioned
-   * device. Call to oneAPI runtime is required to determine the device
-   * type, the USM allocation type and the sycl context it is bound to.
-   *
+   * \brief Unified shared memory allocated on a oneAPI non-partitioned
+   * device. Either a call to oneAPI runtime is required to determine the
+   * device type, the USM allocation type and the sycl context it is
+   * bound to, or the requisite information should be available via the
+   * manager_ctx.
    */
   kDLOneAPI = 14,
   /*! \brief GPU support for next generation WebGPU standard. */


### PR DESCRIPTION
This has no functional impact on the header file, only to modify the text associated with the kDLOneAPI enum. It accomplishes two things:

 - Fixes a spelling mistake with respect to `partition`
 - Adds a small hint that the requisite memory allocation may have the necessary device information via the ```manager_ctx``` struct member.

While its clear that the ```manager_ctx``` is predominantly used for proper data deletion, it can also provide this necessary information associated with SYCL and/or OpenCL peculiarities (namely 'contexts' in both, but also specifically devices for SYCL, etc.).  This should be done in the hope that various implementers of the ```__dlpack__``` standard may try to additionally standardize the required additional information outside of dlpack.

Continues some discussion from #78