### PR TITLE
Use commit hash to download lint script for CI failure

### DIFF
--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 
 if [ ! -f bin/lint.py ]; then
     echo "Grab linter ..."
-    wget https://raw.githubusercontent.com/dmlc/dmlc-core/main/scripts/lint.py
+    wget https://raw.githubusercontent.com/dmlc/dmlc-core/28c2bfd2a8cf46e632e30d7fec006d3ee4b26b1c/scripts/lint.py
     mv lint.py bin/lint.py
 fi
 


### PR DESCRIPTION
Since it was deleted in https://github.com/dmlc/dmlc-core/pull/693