### PR TITLE
[RFC] Support DLPACK C Functions for Speed Exchange and Stream Handling

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (c) 2017 by Contributors
+ *  Copyright (c) 2017 -  by Contributors
  * \file dlpack.h
  * \brief The common header of DLPack.
  */
@@ -326,7 +326,7 @@ typedef struct DLManagedTensor {
  *
  * \note This is the current standard DLPack exchange data structure.
  */
-struct DLManagedTensorVersioned {
+typedef struct DLManagedTensorVersioned {
   /*!
    * \brief The API and ABI version of the current managed Tensor
    */
@@ -360,7 +360,86 @@ struct DLManagedTensorVersioned {
   uint64_t flags;
   /*! \brief DLTensor which is being memory managed */
   DLTensor dl_tensor;
-};
+} DLManagedTensorVersioned;
+
+//--------------------------------------------------------------------
+// DLPack C functions for speed exchange
+//--------------------------------------------------------------------
+/*
+ * \brief A generic C-style allocator that exposes allocation of a Tensor/Array.
+ *
+ * Array/Tensor libraries can store this field as an int in the type of the Tensor/Array.
+ *
+ * mypackage.Tensor.__c_dlpack_tensor_allocator__ = MyPackageDLPackTensorAllocator
+ *
+ * This information can then be used to set allocators of a callee to run allocations.
+ *
+ * This particular function does not assume a Python environment; as a result,
+ * the error handling mechanism is different from Python-related functions.
+ *
+ * \param prototype The prototype DLTensor to offer details about the device and shape.
+ *                  Other field information will be ignored during allocation.
+ * \param out The output DLManagedTensorVersioned.
+ * \param error_ctx The context to set the error.
+ * \param SetError The function to set the error.
+ * \return 0 on success, -1 on failure.
+ *         The callee should call SetError(error_ctx, kind, message) to set the error kind and message.
+ * \note Error propagation via SetError.
+ */
+typedef int (*DLPackTensorAllocator)(                                       //
+  DLTensor* prototype, DLManagedTensorVersioned** out, void* error_ctx,     //
+  void (*SetError)(void* error_ctx, const char* kind, const char* message)  //
+);
+
+/*!
+ * \brief Exports a PyObject* Tensor/NDArray to a DLManagedTensorVersioned.
+ *
+ * This function is a C-style function pointer to quickly convert a PyObject* Tensor/NDArray
+ * to a DLManagedTensorVersioned without going through the Python Interpreter.
+ *
+ * It also provides an option to query the current context stream of the device provided
+ * by the tensor.
+ *
+ * Array/Tensor libraries can store this field as an int in the type of the Tensor/Array.
+ *
+ * mypackage.Tensor.__c_dlpack_from_pyobject__ = MyPackageDLPackFromPyObject
+ *
+ * This information can then be picked up by importers and libraries to run the speed conversion.
+ * This function should not throw any exceptions; if it fails, it should return -1 and
+ * set the error message via PyErr_SetXXX.
+ *
+ * \param py_object The Python object to convert; this should be PyObject*.
+ *                  We use void* to avoid dependency on Python.h.
+ * \param out The output DLManagedTensorVersioned.
+ * \param optional_out_env_stream Outputs the current context stream of the device provided
+ *                   by the tensor; it can be NULL, in which case the stream will not be queried.
+ * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
+ * \note We use void* to avoid dependency on Python.h, so this specific type is
+ *       not dependent on Python.h and can be copied to dlpack.h.
+ */
+typedef int (*DLPackFromPyObject)(                              //
+  void* py_object,                                              //
+  DLManagedTensorVersioned** out,                               //
+  void** optional_out_env_stream                                //
+);
+
+/*!
+ * \brief Imports a DLManagedTensorVersioned to a PyObject* Tensor/NDArray.
+ *
+ * This function is a C-style function pointer to quickly convert a DLManagedTensorVersioned
+ * to a PyObject* without going through the Python Interpreter.
+ *
+ * Array/Tensor libraries can store this field as an int in the type of the Tensor/Array.
+ *
+ * mypackage.Tensor.__c_dlpack_to_pyobject__ = MyPackageDLPackToPyObject
+ *
+ * \param tensor The DLManagedTensorVersioned to convert.
+ * \param out_py_object The output Python object.
+ * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
+ * \note We use void* to avoid dependency on Python.h, so this specific type is
+ *       not dependent on Python.h and can be copied to dlpack.h.
+ */
+typedef int (*DLPackToPyObject)(DLManagedTensorVersioned* tensor, void** out_py_object);
 
 #ifdef __cplusplus
 }  // DLPACK_EXTERN_C

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -407,7 +407,16 @@ typedef int (*DLPackManagedTensorAllocator)(                                //
  *
  * \param py_object The Python object to convert; this should be PyObject*.
  *                  We use void* to avoid dependency on Python.h.
+ *
+ * \param max_version The maximum version of DLPack support that consumer supports.
+ *                    Consumer should fill in their own version here, this parameter is not null.
+ *                    Producer can use this information to produce the appropriate
+ *                    DLManagedTensorVersioned for maximum compatibility if needed.
+ *                    This field is primarily used for future compatibility in case
+ *                    of major version bump and ABI-breaking changes.
+ *
  * \param out The output DLManagedTensorVersioned.
+ *
  * \param optional_out_env_stream Outputs the current context stream of the device provided
  *                   by the tensor; it can be NULL, in which case the stream will not be queried.
  *                   optional_out_env_stream should points to cudaStream_t in the case of CUDA.
@@ -420,6 +429,7 @@ typedef int (*DLPackManagedTensorAllocator)(                                //
  */
 typedef int (*DLPackManagedTensorFromPyObject)(                 //
   void* py_object,                                              //
+  const DLPackVersion* max_version,                             //
   DLManagedTensorVersioned** out,                               //
   void** optional_out_env_stream                                //
 );

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -494,6 +494,28 @@ typedef int (*DLPackManagedTensorToPyObjectNoSync)(                //
 );
 
 /*!
+ * \brief DLPackExchangeAPI stable header.
+ * \sa DLPackExchangeAPI
+ */
+typedef struct DLPackExchangeAPIHeader {
+  /*!
+   * \brief The provided DLPack version the consumer must check major version
+   *        compatibility before using this struct.
+   */
+  DLPackVersion version;
+  /*!
+   * \brief Optional pointer to an older DLPackExchangeAPI in the chain.
+   *
+   * It must be NULL if the framework does not support older versions.
+   * If the current major version is larger than the one supported by the
+   * consumer, the consumer may walk this to find an earlier supported version.
+   *
+   * \sa DLPackExchangeAPI
+   */
+  struct DLPackExchangeAPIHeader* prev_version_api;
+} DLPackExchangeAPIHeader;
+
+/*!
  * \brief Framework-specific function pointers table for DLPack exchange.
  *
  * Additionally to `__dlpack__()` we define a C function table sharable by
@@ -518,14 +540,15 @@ typedef int (*DLPackManagedTensorToPyObjectNoSync)(                //
  * \code
  * struct MyDLPackExchangeAPI : public DLPackExchangeAPI {
  *   MyDLPackExchangeAPI() {
- *     version.major = DLPACK_MAJOR_VERSION;
- *     version.minor = DLPACK_MINOR_VERSION;
+ *     header.version.major = DLPACK_MAJOR_VERSION;
+ *     header.version.minor = DLPACK_MINOR_VERSION;
+ *     header.prev_version_api = nullptr;
+ *
  *     managed_tensor_allocator = MyDLPackManagedTensorAllocator;
  *     managed_tensor_from_py_object_no_sync = MyDLPackManagedTensorFromPyObjectNoSync;
  *     managed_tensor_to_py_object_no_sync = MyDLPackManagedTensorToPyObjectNoSync;
  *     dltensor_from_py_object_no_sync = MyDLPackDLTensorFromPyObjectNoSync;
  *     current_work_stream = MyDLPackCurrentWorkStream;
- *     prev_version_api = nullptr;
  *  }
  *
  *  static const DLPackExchangeAPI* Global() {
@@ -561,22 +584,11 @@ typedef int (*DLPackManagedTensorToPyObjectNoSync)(                //
  * shows an example to do so in C++. It should also be reasonably easy
  * to do so in other languages.
  */
-struct DLPackExchangeAPI {
+typedef struct DLPackExchangeAPI {
   /*!
-   * \brief The provided DLPack version the consumer must check major version
-   *        compatibility before using this struct.
+   * \brief The header that remains stable across versions.
    */
-  DLPackVersion version;
-  /*!
-   * \brief Optional pointer to an older DLPackExchangeAPI in the chain.
-   *
-   * It must be NULL if the framework does not support older versions.
-   * If the current major version is larger than the one supported by the
-   * consumer, the consumer may walk this to find an earlier supported version.
-   *
-   * \sa DLPackExchangeAPI
-   */
-  struct DLPackExchangeAPI* prev_version_api;
+  DLPackExchangeAPIHeader header;
   /*!
    * \brief Producer function pointer for DLPackManagedTensorAllocator
    *        This function must not be NULL.
@@ -607,7 +619,7 @@ struct DLPackExchangeAPI {
    * \sa DLPackCurrentWorkStream
    */
   DLPackCurrentWorkStream current_work_stream;
-};
+} DLPackExchangeAPI;
 
 #ifdef __cplusplus
 }  // DLPACK_EXTERN_C

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -369,6 +369,7 @@ typedef struct DLManagedTensorVersioned {
  * \brief A generic C-style allocator that exposes allocation of a Tensor/Array.
  *
  * This information can then be used to set allocators of a callee to run allocations.
+ * This information can then be used to set the callee's allocator to perform allocations.
  * This function can be exposed by the framework through the DLPackExchangeAPI.
  *
  * This particular function does not assume a Python environment; as a result,
@@ -394,44 +395,66 @@ typedef int (*DLPackManagedTensorAllocator)(                                //
  * \brief Exports a PyObject* Tensor/NDArray to a DLManagedTensorVersioned.
  *
  * This function is a C-style function pointer to quickly convert a PyObject* Tensor/NDArray
- * to a DLManagedTensorVersioned without going through the Python Interpreter.
+ * to a DLManagedTensorVersioned without going through the Python interpreter.
  *
  * It also provides an option to query the current context stream of the device provided
  * by the tensor.
  *
  * This function is exposed by the framework through the DLPackExchangeAPI.
  *
- * This information can then be picked up by importers and libraries to run the speed conversion.
+ * This information can then be picked up by importers and libraries to perform a fast conversion.
  * This function should not throw any exceptions; if it fails, it should return -1 and
  * set the error message via PyErr_SetXXX.
  *
  * \param py_object The Python object to convert; this should be PyObject*.
  *                  We use void* to avoid dependency on Python.h.
  *
- * \param max_version The maximum version of DLPack support that consumer supports.
- *                    Consumer should fill in their own version here, this parameter is not null.
- *                    Producer can use this information to produce the appropriate
- *                    DLManagedTensorVersioned for maximum compatibility if needed.
- *                    This field is primarily used for future compatibility in case
- *                    of major version bump and ABI-breaking changes.
- *
  * \param out The output DLManagedTensorVersioned.
  *
- * \param optional_out_env_stream Outputs the current context stream of the device provided
- *                   by the tensor; it can be NULL, in which case the stream will not be queried.
- *                   optional_out_env_stream should points to cudaStream_t in the case of CUDA.
+ * \param optional_out_last_active_stream Outputs the current stream the tensor is synced to.
+ *   It can be NULL, in which case the stream will not be queried.
+ *   optional_out_last_active_stream should point to cudaStream_t in the case of CUDA.
+ *   Note that for frameworks that use a stream context manager, optional_out_last_active_stream
+ *   can be the stream that the context manager was most recently active on.
+ *   The stream is owned by the producer, and the consumer cannot retain it.
+ *   Instead, the consumer can record an event or add wait dependencies to it.
+ *   It is the responsibility of the consumer to synchronize with the stream if necessary.
+ *   The producer may output `reinterpret_cast<void*>(-1)` to indicate that the last active stream
+ *   is not available; in such a case, a device sync is needed to ensure data is ready.
  *
  * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
  * \note We use void* to avoid dependency on Python.h, so this specific type is
  *       not dependent on Python.h and can be copied to dlpack.h.
  *
- * \sa DLPackExchangeAPI
+ * \sa DLPackExchangeAPI, DLPackCurrentWorkStream
  */
 typedef int (*DLPackManagedTensorFromPyObject)(                 //
   void* py_object,                                              //
-  const DLPackVersion* max_version,                             //
   DLManagedTensorVersioned** out,                               //
-  void** optional_out_env_stream                                //
+  void** optional_out_last_active_stream                        //
+);
+
+/*!
+ * \brief Obtain the current work stream of a device.
+ *
+ * This function is a C-style function pointer to obtain the current work stream of a device
+ * for frameworks that rely on a context manager to manage the stream.
+ * For example, it should map to torch.cuda.current_stream in PyTorch.
+ *
+ * This function can be set to NULL if the framework does not rely on a context manager to
+ * manage the stream.
+ *
+ * \param device_type The device type.
+ * \param device_id The device id.
+ * \param optional_out_current_stream The output current work stream.
+ * \return 0 on success, -1 on failure.
+ *
+ * \sa DLPackExchangeAPI
+ */
+typedef int (*DLPackCurrentWorkStream)(                         //
+  DLDevice device_type,                                         //
+  DLDevice device_id,                                           //
+  void** optional_out_current_stream                            //
 );
 
 /*!
@@ -457,13 +480,36 @@ typedef int (*DLPackManagedTensorToPyObject)(                     //
 /*!
  * \brief Framework-specific function pointers table for DLPack exchange.
  *
- * Array/Tensor librarie should statically create and initialize this structure
+ * Guidelines for leveraging DLPackExchangeAPI:
+ *
+ * There are generally two kinds of consumer needs for DLPack exchange:
+ * - N0: library support, where consumer.kernel(x, y, z) would like to run a kernel
+ *       with the data from x, y, z. The consumer is also expected to run the kernel with the same
+ *       stream context as the producer. For example, when x, y, z is torch.Tensor,
+ *       consumer should query exchange_api->optional_current_work_stream to get the
+ *       current stream and launch the kernel with the same stream.
+ *       This setup is necessary for no synchronization in kernel launch and maximum compatibility
+ *       with CUDA graph capture in the producer.
+ *       This is the desirable behavior for library extension support for frameworks like PyTorch.
+ * - N1: data ingestion and retention, in such a case, the consumer is interested in obtaining
+ *       the data from the producer and runs further computation on its own stream.
+ *       In such a case, the consumer can directly query optional_last_active_stream to
+ *       get the last active stream and record a dependency.
+ *
+ * Consumer should consider their needs (N0 or N1) and act accordingly based on the
+ * availability of the function pointer.
+ *
+ * Importantly, optional_current_work_stream may be NULL for frameworks that
+ * do not rely on a context manager to manage the stream, in which case the consumer
+ * should rely on the information in optional_last_active_stream.
+ *
+ * Array/Tensor libraries should statically create and initialize this structure
  * then return a pointer to DLPackExchangeAPI as an int value in Tensor/Array.
- * The DLPackExchangeAPI* should stay alive throughout the lifetime of process.
+ * The DLPackExchangeAPI* should stay alive throughout the lifetime of the process.
  *
  * One simple way to do so is to create a static instance of DLPackExchangeAPI
- * within the framework and return a pointer to it, the following code
- * shows an example to do so in c++. It should also be reasonably easy
+ * within the framework and return a pointer to it. The following code
+ * shows an example to do so in C++. It should also be reasonably easy
  * to do so in other languages.
  *
  * \code
@@ -474,6 +520,8 @@ typedef int (*DLPackManagedTensorToPyObject)(                     //
  *     managed_tensor_allocator = MyDLPackManagedTensorAllocator;
  *     managed_tensor_from_py_object = MyDLPackManagedTensorFromPyObject;
  *     managed_tensor_to_py_object = MyDLPackManagedTensorToPyObject
+ *     optional_current_work_stream = MyDLPackCurrentWorkStream;
+ *     prev_version_api = nullptr;
  *  }
  *
  *  static const DLPackExchangeAPI* Global() {
@@ -484,9 +532,9 @@ typedef int (*DLPackManagedTensorToPyObject)(                     //
  * \endcode
  *
  * Each framework should attach a dunder `__c_dlpack_exchange_api__` integer
- * to point to the pointer of the DLPackExchangeAPI*
+ * to point to the DLPackExchangeAPI* pointer.
  *
- * Importantly the attributed should be attached to the class of the Tensor, not the instance.
+ * Importantly, the attribute should be attached to the class of the Tensor, not the instance.
  *
  * mypackage.Tensor.__c_dlpack_exchange_api__ = MyPackageDLPackExchangeAPI
  *
@@ -499,6 +547,14 @@ struct DLPackExchangeAPI {
    * \brief The current DLPack version.
    */
   DLPackVersion version;
+  /*!
+   * \brief Optional pointer to an older DLPackExchangeAPI in the chain.
+   *
+   * It should be set to NULL if the framework does not support older versions.
+   *
+   * \sa DLPackExchangeAPI
+   */
+  DLPackExchangeAPI* prev_version_api;
   /*!
    * \brief Framework-specific function pointer for DLPackManagedTensorAllocator
    * \sa DLPackManagedTensorAllocator
@@ -514,6 +570,14 @@ struct DLPackExchangeAPI {
    * \sa DLPackManagedTensorToPyObject
    */
   DLPackManagedTensorToPyObject managed_tensor_to_py_object;
+  /*!
+   * \brief Framework-specific function pointer for DLPackCurrentWorkStream
+   *
+   * This function can be set to NULL if the framework does not rely on context manager to manage the stream.
+   *
+   * \sa DLPackCurrentWorkStream
+   */
+  DLPackCurrentWorkStream optional_current_work_stream;
 };
 
 #ifdef __cplusplus

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -482,7 +482,7 @@ typedef int (*DLPackCurrentWorkStream)(                         //
  * This function is exposed by the framework through the DLPackExchangeAPI.
  *
  * \param tensor The DLManagedTensorVersioned to convert the ownership of the
- *        the data is stolen.
+ *        tensor is stolen.
  * \param out_py_object The output Python object.
  * \return 0 on success, -1 on failure with a Python exception set.
  *

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -362,57 +362,51 @@ typedef struct DLManagedTensorVersioned {
   DLTensor dl_tensor;
 } DLManagedTensorVersioned;
 
-//--------------------------------------------------------------------
-// DLPack C functions for speed exchange
-//--------------------------------------------------------------------
+//----------------------------------------------------------------------
+// DLPack `__c_dlpack_exchange_api__` fast exchange protocol definitions
+//----------------------------------------------------------------------
 /*!
- * \brief A generic C-style allocator that exposes allocation of a Tensor/Array.
+ * \brief Request a producer library to create a new tensor.
  *
- * This information can then be used to set allocators of a callee to run allocations.
- * This information can then be used to set the callee's allocator to perform allocations.
- * This function can be exposed by the framework through the DLPackExchangeAPI.
+ * Create a new `DLManagedTensorVersioned` within the context of the producer
+ * library. The allocation is defined via the prototype DLTensor.
  *
- * This particular function does not assume a Python environment; as a result,
- * the error handling mechanism is different from Python-related functions.
+ * This function is exposed by the framework through the DLPackExchangeAPI.
  *
- * \param prototype The prototype DLTensor to offer details about the device and shape.
- *                  Other field information will be ignored during allocation.
+ * \param prototype The prototype DLTensor. Only the dtype, ndim, shape,
+ *        and device fields are used.
  * \param out The output DLManagedTensorVersioned.
- * \param error_ctx The context to set the error.
+ * \param error_ctx Context for `SetError`.
  * \param SetError The function to set the error.
- * \return 0 on success, -1 on failure.
- *         The callee should call SetError(error_ctx, kind, message) to set the error kind and message.
- * \note Error propagation via SetError.
+ * \return The owning DLManagedTensorVersioned* or NULL on failure.
+ *         SetError is called exactly when NULL is returned (the implementor
+ *         must ensure this).
+ * \note - As a C function, must not thrown C++ exceptions.
+ *       - Error propagation via SetError to avoid any direct need
+ *         of Python API. Due to this `SetError` may have to ensure the GIL is
+ *         held since it will presumably set a Python error.
  *
  * \sa DLPackExchangeAPI
  */
-typedef int (*DLPackManagedTensorAllocator)(                                //
-  DLTensor* prototype, DLManagedTensorVersioned** out, void* error_ctx,     //
-  void (*SetError)(void* error_ctx, const char* kind, const char* message)  //
+typedef int (*DLPackManagedTensorAllocator)(                                         //
+  DLTensor* prototype, DLManagedTensorVersioned** out, void* error_ctx,              //
+  void (*SetError)(void* error_ctx, const char* kind, const char* message)           //
 );
 
 /*!
  * \brief Exports a PyObject* Tensor/NDArray to a DLManagedTensorVersioned.
- *
- * This function is a C-style function pointer to quickly convert a PyObject* Tensor/NDArray
- * to a DLManagedTensorVersioned without going through the Python interpreter.
  *
  * This function does not perform any stream synchronization. The consumer should query
  * DLPackCurrentWorkStream to get the current work stream and launch kernels on it.
  *
  * This function is exposed by the framework through the DLPackExchangeAPI.
  *
- * This information can then be picked up by importers and libraries to perform a fast conversion.
- * This function should not throw any exceptions; if it fails, it should return -1 and
- * set the error message via PyErr_SetXXX.
- *
- * \param py_object The Python object to convert; this should be PyObject*.
- *                  We use void* to avoid dependency on Python.h.
- *
- * \param out The output DLManagedTensorVersioned.
- * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
- * \note We use void* to avoid dependency on Python.h, so this specific type is
- *       not dependent on Python.h and can be copied to dlpack.h.
+ * \param py_object The Python object to convert. Must have the same type
+ *        as the one the `DLPackExchangeAPI` was discovered from.
+ * \return The owning DLManagedTensorVersioned* or NULL on failure with a
+ *         Python exception set. If the data cannot be described using DLPack
+ *         this should be a BufferError if possible.
+ * \note - As a C function, must not thrown C++ exceptions.
  *
  * \sa DLPackExchangeAPI, DLPackCurrentWorkStream
  */
@@ -422,38 +416,26 @@ typedef int (*DLPackManagedTensorFromPyObjectNoSync)(                 //
 );
 
 /*!
- * \brief Exports a PyObject* Tensor/NDArray to a DLTensor whose space is pre-allocated on stack.
+ * \brief Exports a PyObject* Tensor/NDArray to a provided DLTensor.
  *
- * This function is a C-style function pointer to quickly convert a PyObject* Tensor/NDArray
- * to a DLTensor whose space is pre-allocated on stack without going through the Python interpreter.
+ * This function provides a faster interface for temporary, non-owning, exchange.
+ * The producer (implementor) still owns the memory of data, strides, shape.
+ * The liveness of the DLTensor and the data it views is only guaranteed until
+ * control is returned.
  *
- * This is an non-owning conversion, the producer still owns the memory of data, strides, shape.
- * The liveness of DLTensor is only guaranteed until the consumer returns control to the caller.
- *
- * In the context of this function, we expect the producer to allocated space for data, strides and shape.
+ * This function currently assumes that the producer (implementor) can fill
+ * in the DLTensor shape and strides without the need for temporary allocations.
  *
  * This function does not perform any stream synchronization. The consumer should query
  * DLPackCurrentWorkStream to get the current work stream and launch kernels on it.
  *
- * This function is useful when the consumer do not need to retain the tensor memory.
- * It generally can provide about 2x faster conversion than DLPackManagedTensorFromPyObjectNoSync.
- *
- * For cases where consumer may needs to reorganize the tensor memory via temporary managed copy,
- * DLPackManagedTensorFromPyObjectNoSync should be used.
- *
  * This function is exposed by the framework through the DLPackExchangeAPI.
  *
- * This information can then be picked up by importers and libraries to perform a fast conversion.
- * This function should not throw any exceptions; if it fails, it should return -1 and
- * set the error message via PyErr_SetXXX.
- *
- * \param py_object The Python object to convert; this should be PyObject*.
- *                  We use void* to avoid dependency on Python.h.
- *
+ * \param py_object The Python object to convert. Must have the same type
+ *        as the one the `DLPackExchangeAPI` was discovered from.
  * \param out The output DLTensor, whose space is pre-allocated on stack.
- * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
- * \note We use void* to avoid dependency on Python.h, so this specific type is
- *       not dependent on Python.h and can be copied to dlpack.h.
+ * \return 0 on success, -1 on failure with a Python exception set.
+ * \note - As a C function, must not thrown C++ exceptions.
  *
  * \sa DLPackExchangeAPI, DLPackCurrentWorkStream
  */
@@ -465,21 +447,21 @@ typedef int (*DLPackDLTensorFromPyObjectNoSync)(                      //
 /*!
  * \brief Obtain the current work stream of a device.
  *
- * This function is a C-style function pointer to obtain the current work stream
- * of a device for frameworks that rely on a context manager to manage the stream.
+ * Obtain the current work stream of a device from the producer framework.
  * For example, it should map to torch.cuda.current_stream in PyTorch.
  *
- * This function can be set to NULL if the framework does not rely on a context manager
- * to manage the stream. However, we encourage frameworks to provide this function
- * if possible.
- *
- * As if this field is not set, likely consumer cannot safely do stream based
- * exchange based on the
+ * When device_type is kDLCPU, the consumer do not have to query the stream
+ * and the producer can simply return NULL when queried.
+ * The consumer do not have to do anything on stream sync or setting.
+ * So CPU only framework can just provide a dummy implementation that
+ * always set out_current_stream[0] to NULL.
  *
  * \param device_type The device type.
  * \param device_id The device id.
  * \param out_current_stream The output current work stream.
- * \return 0 on success, -1 on failure.
+ *
+ * \return 0 on success, -1 on failure with a Python exception set.
+ * \note - As a C function, must not thrown C++ exceptions.
  *
  * \sa DLPackExchangeAPI
  */
@@ -492,54 +474,47 @@ typedef int (*DLPackCurrentWorkStream)(                         //
 /*!
  * \brief Imports a DLManagedTensorVersioned to a PyObject* Tensor/NDArray.
  *
- * This function is a C-style function pointer to quickly convert a DLManagedTensorVersioned
- * to a PyObject* without going through the Python Interpreter.
+ * Convert an owning DLManagedTensorVersioned* to the Python tensor of the
+ * producer (implementor) library with the correct type.
  *
  * This function does not perform any stream synchronization.
  *
  * This function is exposed by the framework through the DLPackExchangeAPI.
  *
- * \param tensor The DLManagedTensorVersioned to convert.
+ * \param tensor The DLManagedTensorVersioned to convert the ownership of the
+ *        the data is stolen.
  * \param out_py_object The output Python object.
- * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
- * \note We use void* to avoid dependency on Python.h, so this specific type is
- *       not dependent on Python.h and can be copied to dlpack.h.
+ * \return 0 on success, -1 on failure with a Python exception set.
  *
  * \sa DLPackExchangeAPI
  */
-typedef int (*DLPackManagedTensorToPyObjectNoSync)(                     //
-  DLManagedTensorVersioned* tensor, void** out_py_object                //
+typedef int (*DLPackManagedTensorToPyObjectNoSync)(                //
+  DLManagedTensorVersioned* tensor,                                //
+  void** out_py_object                                             //
 );
 
 /*!
  * \brief Framework-specific function pointers table for DLPack exchange.
  *
- * Guidelines for leveraging DLPackExchangeAPI:
+ * Additionally to `__dlpack__()` we define a C function table sharable by
+ * Python implementations via `__c_dlpack_exchange_api__`.
+ * This attribute must be set on the type as a Python integer compatible
+ * with `PyLong_FromVoidPtr`/`PyLong_AsVoidPtr`.
  *
- * There are generally two kinds of consumer needs for DLPack exchange:
- * - N0: library support, where consumer.kernel(x, y, z) would like to run a kernel
- *       with the data from x, y, z. The consumer is also expected to run the kernel with the same
- *       stream context as the producer. For example, when x, y, z is torch.Tensor,
- *       consumer should query exchange_api->current_work_stream to get the
- *       current stream and launch the kernel with the same stream.
- *       This setup is necessary for no synchronization in kernel launch and maximum compatibility
- *       with CUDA graph capture in the producer.
- *       This is the desirable behavior for library extension support for frameworks like PyTorch.
- * - N1: data ingestion and retention
+ * A consumer library may use a pattern such as:
  *
- * Note that obj.__dlpack__() API should provide useful ways for N1.
- * The primary focus of the current DLPackExchangeAPI is to enable faster exchange N0
- * with the support of the function pointer current_work_stream.
+ * \code
  *
- * Array/Tensor libraries should statically create and initialize this structure
- * then return a pointer to DLPackExchangeAPI as an int value in Tensor/Array.
- * The DLPackExchangeAPI* should stay alive throughout the lifetime of the process.
+ * PyObject *api_obj = type(tensor_obj).__c_dlpack_exchange_api__;  // as C-code
+ * MyDLPackExchangeAPI *api = PyLong_AsVoidPtr(api_obj);
+ * if (api == NULL && PyErr_Occurred()) { goto handle_error; }
  *
- * One simple way to do so is to create a static instance of DLPackExchangeAPI
- * within the framework and return a pointer to it. The following code
- * shows an example to do so in C++. It should also be reasonably easy
- * to do so in other languages.
+ * \endcode
  *
+ * Note that this must be defined on the type. The consumer should look up the
+ * attribute on the type and may cache the result for each unique type.
+ *
+ * The precise API table is given by:
  * \code
  * struct MyDLPackExchangeAPI : public DLPackExchangeAPI {
  *   MyDLPackExchangeAPI() {
@@ -560,55 +535,75 @@ typedef int (*DLPackManagedTensorToPyObjectNoSync)(                     //
  * };
  * \endcode
  *
- * Each framework should attach a dunder `__c_dlpack_exchange_api__` integer
- * to point to the DLPackExchangeAPI* pointer.
+ * Guidelines for leveraging DLPackExchangeAPI:
  *
- * Importantly, the attribute should be attached to the class of the Tensor, not the instance.
+ * There are generally two kinds of consumer needs for DLPack exchange:
+ * - N0: library support, where consumer.kernel(x, y, z) would like to run a kernel
+ *       with the data from x, y, z. The consumer is also expected to run the kernel with the same
+ *       stream context as the producer. For example, when x, y, z is torch.Tensor,
+ *       consumer should query exchange_api->current_work_stream to get the
+ *       current stream and launch the kernel with the same stream.
+ *       This setup is necessary for no synchronization in kernel launch and maximum compatibility
+ *       with CUDA graph capture in the producer.
+ *       This is the desirable behavior for library extension support for frameworks like PyTorch.
+ * - N1: data ingestion and retention
  *
- * mypackage.Tensor.__c_dlpack_exchange_api__ = MyPackageDLPackExchangeAPI
+ * Note that obj.__dlpack__() API should provide useful ways for N1.
+ * The primary focus of the current DLPackExchangeAPI is to enable faster exchange N0
+ * with the support of the function pointer current_work_stream.
  *
- * or equivalently:
+ * Array/Tensor libraries should statically create and initialize this structure
+ * then return a pointer to DLPackExchangeAPI as an int value in Tensor/Array.
+ * The DLPackExchangeAPI* must stay alive throughout the lifetime of the process.
  *
- * type(tensor_obj).__c_dlpack_exchange_api__ = MyPackageDLPackExchangeAPI
+ * One simple way to do so is to create a static instance of DLPackExchangeAPI
+ * within the framework and return a pointer to it. The following code
+ * shows an example to do so in C++. It should also be reasonably easy
+ * to do so in other languages.
  */
 struct DLPackExchangeAPI {
   /*!
-   * \brief The current DLPack version.
+   * \brief The provided DLPack version the consumer must check major version
+   *        compatibility before using this struct.
    */
   DLPackVersion version;
   /*!
    * \brief Optional pointer to an older DLPackExchangeAPI in the chain.
    *
-   * It should be set to NULL if the framework does not support older versions.
+   * It must be NULL if the framework does not support older versions.
+   * If the current major version is larger than the one supported by the
+   * consumer, the consumer may walk this to find an earlier supported version.
    *
    * \sa DLPackExchangeAPI
    */
   struct DLPackExchangeAPI* prev_version_api;
   /*!
-   * \brief Framework-specific function pointer for DLPackManagedTensorAllocator
+   * \brief Producer function pointer for DLPackManagedTensorAllocator
+   *        This function must be not NULL.
    * \sa DLPackManagedTensorAllocator
    */
   DLPackManagedTensorAllocator managed_tensor_allocator;
   /*!
-   * \brief Framework-specific function pointer for DLPackManagedTensorFromPyObject
+   * \brief Producer function pointer for DLPackManagedTensorFromPyObject
+   *        This function must be not NULL.
    * \sa DLPackManagedTensorFromPyObject
    */
   DLPackManagedTensorFromPyObjectNoSync managed_tensor_from_py_object_no_sync;
   /*!
-   * \brief Framework-specific function pointer for DLPackManagedTensorToPyObject
+   * \brief Producer function pointer for DLPackManagedTensorToPyObject
+   *        This function must be not NULL.
    * \sa DLPackManagedTensorToPyObject
    */
   DLPackManagedTensorToPyObjectNoSync managed_tensor_to_py_object_no_sync;
   /*!
-   * \brief Framework-specific function pointer for DLPackDLTensorFromPyObject
+   * \brief Producer function pointer for DLPackDLTensorFromPyObject
+   *        This function can be NULL when the producer does not support this function.
    * \sa DLPackDLTensorFromPyObjectNoSync
    */
   DLPackDLTensorFromPyObjectNoSync dltensor_from_py_object_no_sync;
   /*!
-   * \brief Framework-specific function pointer for DLPackCurrentWorkStream
-   *
-   * This function can be set to NULL if the framework does not rely on context manager to manage the stream.
-   *
+   * \brief Producer function pointer for DLPackCurrentWorkStream
+   *        This function must be not NULL.
    * \sa DLPackCurrentWorkStream
    */
   DLPackCurrentWorkStream current_work_stream;

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -365,14 +365,11 @@ typedef struct DLManagedTensorVersioned {
 //--------------------------------------------------------------------
 // DLPack C functions for speed exchange
 //--------------------------------------------------------------------
-/*
+/*!
  * \brief A generic C-style allocator that exposes allocation of a Tensor/Array.
  *
- * Array/Tensor libraries can store this field as an int in the type of the Tensor/Array.
- *
- * mypackage.Tensor.__c_dlpack_tensor_allocator__ = MyPackageDLPackTensorAllocator
- *
  * This information can then be used to set allocators of a callee to run allocations.
+ * This function can be exposed by the framework through the DLPackExchangeAPI.
  *
  * This particular function does not assume a Python environment; as a result,
  * the error handling mechanism is different from Python-related functions.
@@ -385,6 +382,8 @@ typedef struct DLManagedTensorVersioned {
  * \return 0 on success, -1 on failure.
  *         The callee should call SetError(error_ctx, kind, message) to set the error kind and message.
  * \note Error propagation via SetError.
+ *
+ * \sa DLPackExchangeAPI
  */
 typedef int (*DLPackTensorAllocator)(                                       //
   DLTensor* prototype, DLManagedTensorVersioned** out, void* error_ctx,     //
@@ -400,9 +399,7 @@ typedef int (*DLPackTensorAllocator)(                                       //
  * It also provides an option to query the current context stream of the device provided
  * by the tensor.
  *
- * Array/Tensor libraries can store this field as an int in the type of the Tensor/Array.
- *
- * mypackage.Tensor.__c_dlpack_from_pyobject__ = MyPackageDLPackFromPyObject
+ * This function is exposed by the framework through the DLPackExchangeAPI.
  *
  * This information can then be picked up by importers and libraries to run the speed conversion.
  * This function should not throw any exceptions; if it fails, it should return -1 and
@@ -416,6 +413,8 @@ typedef int (*DLPackTensorAllocator)(                                       //
  * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
  * \note We use void* to avoid dependency on Python.h, so this specific type is
  *       not dependent on Python.h and can be copied to dlpack.h.
+ *
+ * \sa DLPackExchangeAPI
  */
 typedef int (*DLPackFromPyObject)(                              //
   void* py_object,                                              //
@@ -429,17 +428,70 @@ typedef int (*DLPackFromPyObject)(                              //
  * This function is a C-style function pointer to quickly convert a DLManagedTensorVersioned
  * to a PyObject* without going through the Python Interpreter.
  *
- * Array/Tensor libraries can store this field as an int in the type of the Tensor/Array.
- *
- * mypackage.Tensor.__c_dlpack_to_pyobject__ = MyPackageDLPackToPyObject
+ * This function is exposed by the framework through the DLPackExchangeAPI.
  *
  * \param tensor The DLManagedTensorVersioned to convert.
  * \param out_py_object The output Python object.
  * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
  * \note We use void* to avoid dependency on Python.h, so this specific type is
  *       not dependent on Python.h and can be copied to dlpack.h.
+ *
+ * \sa DLPackExchangeAPI
  */
 typedef int (*DLPackToPyObject)(DLManagedTensorVersioned* tensor, void** out_py_object);
+
+/*!
+ * \brief Framework-specific function pointers table for DLPack exchange.
+ *
+ * Array/Tensor librarie should statically create and initialize this structure
+ * then return a pointer to DLPackExchangeAPI as an int value in Tensor/Array.
+ * The DLPackExchangeAPI* should stay alive throughout the lifetime of process.
+ *
+ * One simple way to do so is to create a static instance of DLPackExchangeAPI
+ * within the framework and return a pointer to it, the following code
+ * shows an example to do so in c++. It should also be reasonably easy
+ * to do so in other languages.
+ *
+ * \code
+ * struct MyDLPackExchangeAPI : public DLPackExchangeAPI {
+ *   MyDLPackExchangeAPI() {
+ *     version.major = DLPACK_MAJOR_VERSION;
+ *     version.minor = DLPACK_MINOR_VERSION;
+ *     tensor_allocator = MyDLPackTensorAllocator;
+ *     dlpack_from_py_object = MyDLPackFromPyObject;
+ *     dlpack_to_py_object = MyDLPackToPyObject
+ *  }
+ *
+ *  const DLPackExchangeAPI* Global() {
+ *     static MyDLPackExchangeAPI inst;
+ *     return &inst;
+ *  }
+ * };
+ * \endcode
+ *
+ * mypackage.Tensor.__c_dlpack_exchange_api__ = MyPackageDLPackExchangeAPI
+ */
+struct DLPackExchangeAPI {
+  /*!
+   * \brief The current DLPack version.
+   */
+  DLPackVersion version;
+  /*!
+   * \brief Framework-specific function pointer for DLPackTensorAllocator
+   * \sa DLPackTensorAllocator
+   */
+  DLPackTensorAllocator tensor_allocator;
+  /*!
+   * \brief Framework-specific function pointer for DLPackFromPyObject
+   * \sa DLPackFromPyObject
+   */
+  DLPackFromPyObject dlpack_from_py_object;
+  /*!
+   * \brief Framework-specific function pointer for DLPackToPyObject
+   * \sa DLPackToPyObject
+   */
+  DLPackToPyObject dlpack_to_py_object;
+};
 
 #ifdef __cplusplus
 }  // DLPACK_EXTERN_C

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -397,8 +397,8 @@ typedef int (*DLPackManagedTensorAllocator)(                                //
  * This function is a C-style function pointer to quickly convert a PyObject* Tensor/NDArray
  * to a DLManagedTensorVersioned without going through the Python interpreter.
  *
- * It also provides an option to query the current context stream of the device provided
- * by the tensor.
+ * This function does not perform any stream synchronization. The consumer should query
+ * DLPackCurrentWorkStream to get the current work stream and launch kernels on it.
  *
  * This function is exposed by the framework through the DLPackExchangeAPI.
  *
@@ -410,51 +410,83 @@ typedef int (*DLPackManagedTensorAllocator)(                                //
  *                  We use void* to avoid dependency on Python.h.
  *
  * \param out The output DLManagedTensorVersioned.
- *
- * \param optional_out_last_active_stream Outputs the current stream the tensor is synced to.
- *   It can be NULL, in which case the stream will not be queried.
- *   optional_out_last_active_stream should point to cudaStream_t in the case of CUDA.
- *   Note that for frameworks that use a stream context manager, optional_out_last_active_stream
- *   can be the stream that the context manager was most recently active on.
- *   The stream is owned by the producer, and the consumer cannot retain it.
- *   Instead, the consumer can record an event or add wait dependencies to it.
- *   It is the responsibility of the consumer to synchronize with the stream if necessary.
- *   The producer may output `reinterpret_cast<void*>(-1)` to indicate that the last active stream
- *   is not available; in such a case, a device sync is needed to ensure data is ready.
- *
  * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
  * \note We use void* to avoid dependency on Python.h, so this specific type is
  *       not dependent on Python.h and can be copied to dlpack.h.
  *
  * \sa DLPackExchangeAPI, DLPackCurrentWorkStream
  */
-typedef int (*DLPackManagedTensorFromPyObject)(                 //
-  void* py_object,                                              //
-  DLManagedTensorVersioned** out,                               //
-  void** optional_out_last_active_stream                        //
+typedef int (*DLPackManagedTensorFromPyObjectNoSync)(                 //
+  void* py_object,                                                    //
+  DLManagedTensorVersioned** out                                      //
+);
+
+/*!
+ * \brief Exports a PyObject* Tensor/NDArray to a DLTensor whose space is pre-allocated on stack.
+ *
+ * This function is a C-style function pointer to quickly convert a PyObject* Tensor/NDArray
+ * to a DLTensor whose space is pre-allocated on stack without going through the Python interpreter.
+ *
+ * This is an non-owning conversion, the producer still owns the memory of data, strides, shape.
+ * The liveness of DLTensor is only guaranteed until the consumer returns control to the caller.
+ *
+ * In the context of this function, we expect the producer to allocated space for data, strides and shape.
+ *
+ * This function does not perform any stream synchronization. The consumer should query
+ * DLPackCurrentWorkStream to get the current work stream and launch kernels on it.
+ *
+ * This function is useful when the consumer do not need to retain the tensor memory.
+ * It generally can provide about 2x faster conversion than DLPackManagedTensorFromPyObjectNoSync.
+ *
+ * For cases where consumer may needs to reorganize the tensor memory via temporary managed copy,
+ * DLPackManagedTensorFromPyObjectNoSync should be used.
+ *
+ * This function is exposed by the framework through the DLPackExchangeAPI.
+ *
+ * This information can then be picked up by importers and libraries to perform a fast conversion.
+ * This function should not throw any exceptions; if it fails, it should return -1 and
+ * set the error message via PyErr_SetXXX.
+ *
+ * \param py_object The Python object to convert; this should be PyObject*.
+ *                  We use void* to avoid dependency on Python.h.
+ *
+ * \param out The output DLTensor, whose space is pre-allocated on stack.
+ * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
+ * \note We use void* to avoid dependency on Python.h, so this specific type is
+ *       not dependent on Python.h and can be copied to dlpack.h.
+ *
+ * \sa DLPackExchangeAPI, DLPackCurrentWorkStream
+ */
+typedef int (*DLPackDLTensorFromPyObjectNoSync)(                      //
+  void* py_object,                                                    //
+  DLTensor* out                                                       //
 );
 
 /*!
  * \brief Obtain the current work stream of a device.
  *
- * This function is a C-style function pointer to obtain the current work stream of a device
- * for frameworks that rely on a context manager to manage the stream.
+ * This function is a C-style function pointer to obtain the current work stream
+ * of a device for frameworks that rely on a context manager to manage the stream.
  * For example, it should map to torch.cuda.current_stream in PyTorch.
  *
- * This function can be set to NULL if the framework does not rely on a context manager to
- * manage the stream.
+ * This function can be set to NULL if the framework does not rely on a context manager
+ * to manage the stream. However, we encourage frameworks to provide this function
+ * if possible.
+ *
+ * As if this field is not set, likely consumer cannot safely do stream based
+ * exchange based on the
  *
  * \param device_type The device type.
  * \param device_id The device id.
- * \param optional_out_current_stream The output current work stream.
+ * \param out_current_stream The output current work stream.
  * \return 0 on success, -1 on failure.
  *
  * \sa DLPackExchangeAPI
  */
 typedef int (*DLPackCurrentWorkStream)(                         //
-  DLDevice device_type,                                         //
-  DLDevice device_id,                                           //
-  void** optional_out_current_stream                            //
+  DLDeviceType device_type,                                     //
+  int32_t device_id,                                            //
+  void** out_current_stream                                     //
 );
 
 /*!
@@ -462,6 +494,8 @@ typedef int (*DLPackCurrentWorkStream)(                         //
  *
  * This function is a C-style function pointer to quickly convert a DLManagedTensorVersioned
  * to a PyObject* without going through the Python Interpreter.
+ *
+ * This function does not perform any stream synchronization.
  *
  * This function is exposed by the framework through the DLPackExchangeAPI.
  *
@@ -473,8 +507,8 @@ typedef int (*DLPackCurrentWorkStream)(                         //
  *
  * \sa DLPackExchangeAPI
  */
-typedef int (*DLPackManagedTensorToPyObject)(                     //
-  DLManagedTensorVersioned* tensor, void** out_py_object          //
+typedef int (*DLPackManagedTensorToPyObjectNoSync)(                     //
+  DLManagedTensorVersioned* tensor, void** out_py_object                //
 );
 
 /*!
@@ -486,22 +520,16 @@ typedef int (*DLPackManagedTensorToPyObject)(                     //
  * - N0: library support, where consumer.kernel(x, y, z) would like to run a kernel
  *       with the data from x, y, z. The consumer is also expected to run the kernel with the same
  *       stream context as the producer. For example, when x, y, z is torch.Tensor,
- *       consumer should query exchange_api->optional_current_work_stream to get the
+ *       consumer should query exchange_api->current_work_stream to get the
  *       current stream and launch the kernel with the same stream.
  *       This setup is necessary for no synchronization in kernel launch and maximum compatibility
  *       with CUDA graph capture in the producer.
  *       This is the desirable behavior for library extension support for frameworks like PyTorch.
- * - N1: data ingestion and retention, in such a case, the consumer is interested in obtaining
- *       the data from the producer and runs further computation on its own stream.
- *       In such a case, the consumer can directly query optional_last_active_stream to
- *       get the last active stream and record a dependency.
+ * - N1: data ingestion and retention
  *
- * Consumer should consider their needs (N0 or N1) and act accordingly based on the
- * availability of the function pointer.
- *
- * Importantly, optional_current_work_stream may be NULL for frameworks that
- * do not rely on a context manager to manage the stream, in which case the consumer
- * should rely on the information in optional_last_active_stream.
+ * Note that obj.__dlpack__() API should provide useful ways for N1.
+ * The primary focus of the current DLPackExchangeAPI is to enable faster exchange N0
+ * with the support of the function pointer current_work_stream.
  *
  * Array/Tensor libraries should statically create and initialize this structure
  * then return a pointer to DLPackExchangeAPI as an int value in Tensor/Array.
@@ -518,9 +546,10 @@ typedef int (*DLPackManagedTensorToPyObject)(                     //
  *     version.major = DLPACK_MAJOR_VERSION;
  *     version.minor = DLPACK_MINOR_VERSION;
  *     managed_tensor_allocator = MyDLPackManagedTensorAllocator;
- *     managed_tensor_from_py_object = MyDLPackManagedTensorFromPyObject;
- *     managed_tensor_to_py_object = MyDLPackManagedTensorToPyObject
- *     optional_current_work_stream = MyDLPackCurrentWorkStream;
+ *     managed_tensor_from_py_object_no_sync = MyDLPackManagedTensorFromPyObjectNoSync;
+ *     managed_tensor_to_py_object_no_sync = MyDLPackManagedTensorToPyObjectNoSync;
+ *     dltensor_from_py_object_no_sync = MyDLPackDLTensorFromPyObjectNoSync;
+ *     current_work_stream = MyDLPackCurrentWorkStream;
  *     prev_version_api = nullptr;
  *  }
  *
@@ -554,7 +583,7 @@ struct DLPackExchangeAPI {
    *
    * \sa DLPackExchangeAPI
    */
-  DLPackExchangeAPI* prev_version_api;
+  struct DLPackExchangeAPI* prev_version_api;
   /*!
    * \brief Framework-specific function pointer for DLPackManagedTensorAllocator
    * \sa DLPackManagedTensorAllocator
@@ -564,12 +593,17 @@ struct DLPackExchangeAPI {
    * \brief Framework-specific function pointer for DLPackManagedTensorFromPyObject
    * \sa DLPackManagedTensorFromPyObject
    */
-  DLPackManagedTensorFromPyObject managed_tensor_from_py_object;
+  DLPackManagedTensorFromPyObjectNoSync managed_tensor_from_py_object_no_sync;
   /*!
    * \brief Framework-specific function pointer for DLPackManagedTensorToPyObject
    * \sa DLPackManagedTensorToPyObject
    */
-  DLPackManagedTensorToPyObject managed_tensor_to_py_object;
+  DLPackManagedTensorToPyObjectNoSync managed_tensor_to_py_object_no_sync;
+  /*!
+   * \brief Framework-specific function pointer for DLPackDLTensorFromPyObject
+   * \sa DLPackDLTensorFromPyObjectNoSync
+   */
+  DLPackDLTensorFromPyObjectNoSync dltensor_from_py_object_no_sync;
   /*!
    * \brief Framework-specific function pointer for DLPackCurrentWorkStream
    *
@@ -577,7 +611,7 @@ struct DLPackExchangeAPI {
    *
    * \sa DLPackCurrentWorkStream
    */
-  DLPackCurrentWorkStream optional_current_work_stream;
+  DLPackCurrentWorkStream current_work_stream;
 };
 
 #ifdef __cplusplus

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -512,7 +512,7 @@ typedef struct DLPackExchangeAPIHeader {
    *
    * \sa DLPackExchangeAPI
    */
-  struct DLPackExchangeAPIHeader* prev_version_api;
+  struct DLPackExchangeAPIHeader* prev_api;
 } DLPackExchangeAPIHeader;
 
 /*!

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -579,7 +579,7 @@ struct DLPackExchangeAPI {
   struct DLPackExchangeAPI* prev_version_api;
   /*!
    * \brief Producer function pointer for DLPackManagedTensorAllocator
-   *        This function must be not NULL.
+   *        This function must not be NULL.
    * \sa DLPackManagedTensorAllocator
    */
   DLPackManagedTensorAllocator managed_tensor_allocator;

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -385,7 +385,7 @@ typedef struct DLManagedTensorVersioned {
  *
  * \sa DLPackExchangeAPI
  */
-typedef int (*DLPackTensorAllocator)(                                       //
+typedef int (*DLPackManagedTensorAllocator)(                                //
   DLTensor* prototype, DLManagedTensorVersioned** out, void* error_ctx,     //
   void (*SetError)(void* error_ctx, const char* kind, const char* message)  //
 );
@@ -410,13 +410,15 @@ typedef int (*DLPackTensorAllocator)(                                       //
  * \param out The output DLManagedTensorVersioned.
  * \param optional_out_env_stream Outputs the current context stream of the device provided
  *                   by the tensor; it can be NULL, in which case the stream will not be queried.
+ *                   optional_out_env_stream should points to cudaStream_t in the case of CUDA.
+ *
  * \return 0 on success, -1 on failure. PyError should be set if -1 is returned.
  * \note We use void* to avoid dependency on Python.h, so this specific type is
  *       not dependent on Python.h and can be copied to dlpack.h.
  *
  * \sa DLPackExchangeAPI
  */
-typedef int (*DLPackFromPyObject)(                              //
+typedef int (*DLPackManagedTensorFromPyObject)(                 //
   void* py_object,                                              //
   DLManagedTensorVersioned** out,                               //
   void** optional_out_env_stream                                //
@@ -438,7 +440,9 @@ typedef int (*DLPackFromPyObject)(                              //
  *
  * \sa DLPackExchangeAPI
  */
-typedef int (*DLPackToPyObject)(DLManagedTensorVersioned* tensor, void** out_py_object);
+typedef int (*DLPackManagedTensorToPyObject)(                     //
+  DLManagedTensorVersioned* tensor, void** out_py_object          //
+);
 
 /*!
  * \brief Framework-specific function pointers table for DLPack exchange.
@@ -457,19 +461,28 @@ typedef int (*DLPackToPyObject)(DLManagedTensorVersioned* tensor, void** out_py_
  *   MyDLPackExchangeAPI() {
  *     version.major = DLPACK_MAJOR_VERSION;
  *     version.minor = DLPACK_MINOR_VERSION;
- *     tensor_allocator = MyDLPackTensorAllocator;
- *     dlpack_from_py_object = MyDLPackFromPyObject;
- *     dlpack_to_py_object = MyDLPackToPyObject
+ *     managed_tensor_allocator = MyDLPackManagedTensorAllocator;
+ *     managed_tensor_from_py_object = MyDLPackManagedTensorFromPyObject;
+ *     managed_tensor_to_py_object = MyDLPackManagedTensorToPyObject
  *  }
  *
- *  const DLPackExchangeAPI* Global() {
+ *  static const DLPackExchangeAPI* Global() {
  *     static MyDLPackExchangeAPI inst;
  *     return &inst;
  *  }
  * };
  * \endcode
  *
+ * Each framework should attach a dunder `__c_dlpack_exchange_api__` integer
+ * to point to the pointer of the DLPackExchangeAPI*
+ *
+ * Importantly the attributed should be attached to the class of the Tensor, not the instance.
+ *
  * mypackage.Tensor.__c_dlpack_exchange_api__ = MyPackageDLPackExchangeAPI
+ *
+ * or equivalently:
+ *
+ * type(tensor_obj).__c_dlpack_exchange_api__ = MyPackageDLPackExchangeAPI
  */
 struct DLPackExchangeAPI {
   /*!
@@ -477,20 +490,20 @@ struct DLPackExchangeAPI {
    */
   DLPackVersion version;
   /*!
-   * \brief Framework-specific function pointer for DLPackTensorAllocator
-   * \sa DLPackTensorAllocator
+   * \brief Framework-specific function pointer for DLPackManagedTensorAllocator
+   * \sa DLPackManagedTensorAllocator
    */
-  DLPackTensorAllocator tensor_allocator;
+  DLPackManagedTensorAllocator managed_tensor_allocator;
   /*!
-   * \brief Framework-specific function pointer for DLPackFromPyObject
-   * \sa DLPackFromPyObject
+   * \brief Framework-specific function pointer for DLPackManagedTensorFromPyObject
+   * \sa DLPackManagedTensorFromPyObject
    */
-  DLPackFromPyObject dlpack_from_py_object;
+  DLPackManagedTensorFromPyObject managed_tensor_from_py_object;
   /*!
-   * \brief Framework-specific function pointer for DLPackToPyObject
-   * \sa DLPackToPyObject
+   * \brief Framework-specific function pointer for DLPackManagedTensorToPyObject
+   * \sa DLPackManagedTensorToPyObject
    */
-  DLPackToPyObject dlpack_to_py_object;
+  DLPackManagedTensorToPyObject managed_tensor_to_py_object;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR adds support for three C functions to speedup DLPack exchange. As of now, DLPack exchange relies on python functions such as `tensor.__dlpack__()`.

While they works well for common cases, the general overhead of such exchange is at the level of 0.2-0.3 us for very well optimized version, and can go up to 0.4-1 us for less optimized implementation.

For a function that takes three arguments f(a, b, c), assume we run DLPack exchange for each argument, the general conversion overhead usually gets to around 1us and sometimes to 3us.

While such overhead can be acceptable in many settings, in GPU applications the extra 1-3us overhead can still be significant.

This PR proposes four functions for speed exchange DLPack tensors without going through python interpreter.

- DLPackManagedTensorFromPyObjectNoSync for  fast exchange owned tensors into consumer
- DLPackDLTensorFromPyObjectNoSync for fast exchange non-owned tensors into consumer
- DLPackManagedTensorToPyObjectNoSync for fast exchange consumer tensors into producer (return values)
- DLPackCurrentWorkStream for query the current working stream from the stream context

Our preliminary results show that these functions, when incorporated correctly via native extensions such as c/c++, can bring exchange cost to the level of 30ns - 80ns, giving us about one order of maginitude speedup. That means the API overhead of functions like f(a, b, c) will be at 0.2us-0.4us level (including exchange), which is close to what native cpp extension overhead do without exchange.