### PR TITLE
Enforce strides to be not null when ndim is nonzero

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -257,8 +257,9 @@ typedef struct {
   /*! \brief The shape of the tensor */
   int64_t* shape;
   /*!
-   * \brief strides of the tensor (in number of elements, not bytes)
-   *  can be NULL, indicating tensor is compact and row-majored.
+   * \brief strides of the tensor (in number of elements, not bytes),
+   *  can not be NULL if ndim != 0, must points to
+   *  an array of ndim elements that specifies the strides.
    */
   int64_t* strides;
   /*! \brief The offset in bytes to the beginning pointer to data */

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -254,12 +254,23 @@ typedef struct {
   int32_t ndim;
   /*! \brief The data type of the pointer*/
   DLDataType dtype;
-  /*! \brief The shape of the tensor */
+  /*!
+   * \brief The shape of the tensor
+   *
+   *  When ndim == 0, we suggest to set the shape to NULL.
+   */
   int64_t* shape;
   /*!
    * \brief strides of the tensor (in number of elements, not bytes),
    *  can not be NULL if ndim != 0, must points to
    *  an array of ndim elements that specifies the strides.
+   *
+   *  When ndim == 0, we suggest to set the strides to NULL.
+   *
+   *  \note Before DLPack v1.2, strides can be NULL to indicate contiguous data.
+   *        This is not allowed in DLPack v1.2 and later. The rationale
+   *        is to simplify the consumer hanlding, and most frameworks already
+   *        always returns the strides when ndim != 0.
    */
   int64_t* strides;
   /*! \brief The offset in bytes to the beginning pointer to data */

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -269,8 +269,7 @@ typedef struct {
    *
    *  \note Before DLPack v1.2, strides can be NULL to indicate contiguous data.
    *        This is not allowed in DLPack v1.2 and later. The rationale
-   *        is to simplify the consumer hanlding, and most frameworks already
-   *        always returns the strides when ndim != 0.
+   *        is to simplify the consumer handling.
    */
   int64_t* strides;
   /*! \brief The offset in bytes to the beginning pointer to data */

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -19,7 +19,7 @@
 #define DLPACK_MAJOR_VERSION 1
 
 /*! \brief The current minor version of dlpack */
-#define DLPACK_MINOR_VERSION 1
+#define DLPACK_MINOR_VERSION 2
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32
@@ -257,15 +257,16 @@ typedef struct {
   /*!
    * \brief The shape of the tensor
    *
-   *  When ndim == 0, we suggest to set the shape to NULL.
+   *  When ndim == 0, shape can be set to NULL.
    */
   int64_t* shape;
   /*!
    * \brief strides of the tensor (in number of elements, not bytes),
    *  can not be NULL if ndim != 0, must points to
-   *  an array of ndim elements that specifies the strides.
+   *  an array of ndim elements that specifies the strides,
+   *  so consumer can always rely on strides[dim] being valid for 0 <= dim < ndim.
    *
-   *  When ndim == 0, we suggest to set the strides to NULL.
+   *  When ndim == 0, strides can be set to NULL.
    *
    *  \note Before DLPack v1.2, strides can be NULL to indicate contiguous data.
    *        This is not allowed in DLPack v1.2 and later. The rationale


### PR DESCRIPTION
This PR updates the spec to enforce the strides to be not null when the ndim is nonzero.
This is going to help consumers to handle cases more uniformly.