### PR TITLE
Add a kDLTpu and kDLTPUHost for device and host TPU memory.

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -120,6 +120,10 @@ typedef enum {
   kDLMAIA = 17,
   /*! \brief AWS Trainium */
   kDLTrn = 18,
+  /*! \brief Google TPU device */
+  kDLTPU = 19,
+  /*! \brief Google TPU Host device (pinned memory) */
+  kDLTPUHost = 20,
 } DLDeviceType;
 
 /*!


### PR DESCRIPTION
This can be used to share buffers between different clients connected to the same TPU runtime like TorchTPU and JAX.