### PR TITLE
Add kDLAscend for Huawei Ascend NPU device memory

### DIFF
--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -124,6 +124,8 @@ typedef enum {
   kDLTPU = 19,
   /*! \brief Google TPU Host device (pinned memory) */
   kDLTPUHost = 20,
+  /*! \brief Huawei Ascend NPU device */
+  kDLAscend = 21,
 } DLDeviceType;
 
 /*!


### PR DESCRIPTION
## Motivation

Huawei Ascend integrations currently have no dedicated `DLDeviceType` and
therefore have to represent Ascend device memory using `kDLExtDev`.
Because `kDLExtDev` is shared by unrelated extension backends, it cannot
uniquely identify Ascend memory when tensors are exchanged across frameworks
and runtime integrations.

This PR adds `kDLAscend = 21` as the dedicated device type for Huawei Ascend
NPU device memory. It only extends the enumeration and does not change any
existing enum value or ABI layout.

## Naming

`kDLAscend` uses the official and unambiguous Ascend platform name. A generic
name such as `kDLNPU` would be ambiguous across NPU vendors, while
`kDLAscendNPU` would repeat the device category without adding identifying
information. `kDLCANN` was also avoided because CANN is the software stack,
rather than the identity of the device and its memory domain.

This follows the precedent established by
[`kDLMAIA`](https://github.com/dmlc/dlpack/pull/120#discussion_r1470119529),
where DLPack adopted the released product name instead of a vendor- or
generic-NPU-derived name.

## Downstream adoption

After this device type is merged and made available to downstream projects,
we intend to follow up with Ascend integrations—starting with
[`torch_npu`](https://github.com/Ascend/pytorch)—to use `kDLAscend` for
DLPack import and export instead of overloading `kDLExtDev`. Other consumers,
including TVM-FFI and TileLang integrations, can then adopt the same
standardized device identity.